### PR TITLE
to fix crons sorted by frequency

### DIFF
--- a/src/main/python/starlake-orchestration/setup.py
+++ b/src/main/python/starlake-orchestration/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='starlake-orchestration',
-      version='0.3.2',
+      version='0.3.2.1',
       description='Starlake Python Distribution For orchestration',
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/src/main/python/starlake-snowflake/ai/starlake/snowflake/starlake_snowflake_orchestration.py
+++ b/src/main/python/starlake-snowflake/ai/starlake/snowflake/starlake_snowflake_orchestration.py
@@ -15,7 +15,7 @@ from snowflake.core.task import Cron, StoredProcedureCall, Task
 from snowflake.core.task.dagv1 import DAG, DAGTask, DAGOperation, DAGRun, _dag_context_stack
 from snowflake.snowpark import Row, Session
 
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from types import ModuleType
 
@@ -217,8 +217,8 @@ class SnowflakeDag(DAG):
             if computed_cron:
                 schedule = computed_cron
             elif changes:
-                sorted_crons = sort_crons_by_frequency(list(changes.values()))
-                most_frequent_cron = sorted_crons[0][0]
+                sorted_crons_by_frequency: Tuple[Dict[int, List[str]], List[str]] = sort_crons_by_frequency(set(self.scheduled_datasets.values()))
+                most_frequent_cron = sorted_crons_by_frequency[1][0]
                 from datetime import datetime
                 from croniter import croniter
                 iter_cron = croniter(most_frequent_cron, start_time=datetime.now())

--- a/src/main/python/starlake-snowflake/setup.py
+++ b/src/main/python/starlake-snowflake/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='starlake-snowflake',
-      version='0.1.6.0',
+      version='0.1.6.1',
       description='Starlake Python Distribution For Snowflake',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
- update get_cron_frequency as the timedelta between 2 executions of a cron expression
- update sort_crons_by_frequency as a tuple of (cron expressions grouped by frequency, list of cron expressions ordered by frequency in ascending order). For each frequency, sort the list of cron expressions based on the next execution date, from the furthest to the soonest
- update accordingly least and most frequent datasets