### PR TITLE
Fix start_op dataset validation boundary condition

### DIFF
--- a/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_job.py
@@ -664,7 +664,7 @@ class StarlakeAirflowJob(IStarlakeJob[BaseOperator, Dataset], StarlakeAirflowOpt
                                     extra = event.extra or event.dataset.extra or dataset.extra or {}
                                     scheduled_datetime = get_scheduled_datetime(Dataset(uri=dataset.uri, extra=extra))
                                     if scheduled_datetime:
-                                        if scheduled_date_to_check_min >= scheduled_datetime or scheduled_datetime > scheduled_date_to_check_max:
+                                        if scheduled_date_to_check_min > scheduled_datetime or scheduled_datetime > scheduled_date_to_check_max:
                                             print(f"Dataset event {event.id} for {dataset.uri} with scheduled datetime {scheduled_datetime} not between {scheduled_date_to_check_min} and {scheduled_date_to_check_max}")
                                             i += 1
                                         else:

--- a/starlake-orchestration/src/main/python/ai/starlake/common/__init__.py
+++ b/starlake-orchestration/src/main/python/ai/starlake/common/__init__.py
@@ -94,19 +94,24 @@ def sl_schedule(cron: str, start_time: Optional[Union[str, datetime]] = None, fo
         start_time = parser.isoparse(start_time).astimezone(pytz.timezone(timezone))
     return croniter(cron, start_time).get_prev(datetime).strftime(format)
 
-def get_cron_frequency(cron_expression) -> timedelta:
+def get_cron_frequency(cron_expression, cycles: int = 12) -> timedelta:
     """
-    Calculate the timedelta between 2 executions of a cron expression.
+    Calculate the average timedelta between executions of a cron expression.
+    Uses multiple cycles to handle variable month lengths (28-31 days).
+    croniter projects future occurrences mathematically from the expression alone.
     :param cron_expression: A string representing the cron expression.
+    :param cycles: The number of cycles to average over (default: 12).
     :raise ValueError: If the cron expression is invalid.
-    :return: The timedelta between 2 executions of the cron expression.
+    :return: The average timedelta between executions of the cron expression.
     """
     if not is_valid_cron(cron_expression):
         raise ValueError(f"Invalid cron expression: {cron_expression}")
     iter = croniter(cron_expression)
-    next_run = iter.get_next(datetime)
-    next_run_2 = iter.get_next(datetime)
-    return next_run_2 - next_run
+    first_run = iter.get_next(datetime)
+    for _ in range(cycles):
+        last_run = iter.get_next(datetime)
+    total_delta = last_run - first_run
+    return total_delta / cycles
 
 def sort_crons_by_frequency(cron_expressions, reference_time: Optional[datetime] = None, **kwargs) -> Tuple[Dict[int, List[str]], List[str]]:
     """


### PR DESCRIPTION
## Summary

The `start_op` function in `starlake_airflow_job.py` incorrectly rejects valid dataset events when the event datetime falls exactly on the minimum boundary of the scheduled time range. This causes DAGs with multi-frequency dataset dependencies to fail validation inconsistently.

Two bugs have been identified:
1. **Bug 1 (Critical):** Incorrect boundary comparison operator `>=` instead of `>`
2. **Bug 2 (Design):** Non-deterministic `most_frequent_crons` calculation due to variable month lengths

## Bug 1: Incorrect Boundary Comparison

The interval should be `]min, max]` (exclusive left, inclusive right). An event whose `scheduled_datetime` equals `min` is a valid event that should be accepted, not rejected.

**Reproduction case:**
- DAG depends on 3 datasets with crons: annual `0 7 21 10 *`, monthly `0 7 15 * *`, weekly `0 7 * * 1`
- October run (OK): event at `2025-09-21 07:00`, min=`2025-08-21`, check `2025-08-21 >= 2025-09-21` = FALSE -> accepted
- November run (NOK): event at `2025-10-21 07:00`, min=`2025-10-21`, check `2025-10-21 >= 2025-10-21` = TRUE -> **rejected (Should be accepted)**

With fix: `2025-10-21 > 2025-10-21` = FALSE -> accepted

## Bug 2: Non-Deterministic Frequency Calculation

### Problem

The function calculates frequency based on a single interval between two consecutive cron executions. Due to variable month lengths (28-31 days), two monthly crons can appear to have different frequencies depending on execution date:

| Execution Date | Cron `0 7 15 * *` | Cron `0 7 21 * *` | most_frequent_crons |
|---|---|---|---|
| October 15 | 30 days (Nov) | 31 days (Oct) | `['0 7 15 * *']` |
| November 15 | 31 days (Dec) | 30 days (Nov) | `['0 7 21 * *']` |

This changes which cron is selected as "most frequent", which shifts the validation window boundaries unpredictably.

**Proposition**: With 12 cycles instead of 2, both monthly crons produce ~30.44 days average frequency, resulting in `most_frequent_crons = ['0 7 15 * *', '0 7 21 * *']` (both selected consistently).
