### PR TITLE
ci: test pipeline with path-filter alignment (story 1.8)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,16 +214,24 @@ jobs:
       # Each module's setup.py does open("README.md") but the per-module
       # src/main/python/README.md files are NOT tracked in git — Maven's
       # copy-readme execution creates them at build time. Stage them here
-      # or every editable install below fails with FileNotFoundError.
+      # or every package build below fails with FileNotFoundError.
       - name: Stage module READMEs (Maven copy-readme equivalent)
         run: |
           for m in starlake-orchestration starlake-airflow starlake-dagster starlake-snowflake; do
             cp "$m/README.md" "$m/src/main/python/README.md"
           done
 
+      # All installs below are NON-editable: ai/__init__.py and
+      # ai/starlake/__init__.py are regular packages (no namespace
+      # declaration), so editable installs cannot merge the ai.starlake
+      # namespace — each -e package's import finder claims the whole `ai`
+      # tree and shadows the siblings (core's ai.starlake.job disappears
+      # under an editable orchestrator, or vice versa). Regular wheel
+      # installs physically merge the tree in site-packages, which is
+      # exactly what end users get from PyPI.
       - name: Install local core (module under test, or core changed on this PR)
         if: matrix.module == 'orchestration' || needs.detect-changes.outputs.core_changed == 'true'
-        run: uv pip install -e starlake-orchestration/src/main/python/
+        run: uv pip install starlake-orchestration/src/main/python/
 
       # Version-parameterized: the orchestrator pin comes from the matrix
       # entry, not from hardcoded literals. Airflow's official constraints
@@ -238,14 +246,14 @@ jobs:
             airflow)
               uv pip install "apache-airflow==${{ matrix.orchestrator_version }}" \
                 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${{ matrix.orchestrator_version }}/constraints-${{ env.PYTHON_VERSION }}.txt"
-              uv pip install -e starlake-airflow/src/main/python/
+              uv pip install starlake-airflow/src/main/python/
               ;;
             dagster)
               uv pip install "dagster==${{ matrix.orchestrator_version }}" "${{ matrix.companion }}"
-              uv pip install -e starlake-dagster/src/main/python/
+              uv pip install starlake-dagster/src/main/python/
               ;;
             snowflake)
-              uv pip install -e starlake-snowflake/src/main/python/
+              uv pip install starlake-snowflake/src/main/python/
               ;;
             *)
               echo "Unknown matrix module: ${{ matrix.module }}" >&2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,290 @@
+name: Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - '**'
+  push:
+    branches:
+      - main
+
+# dorny/paths-filter reads the PR file list via the GitHub API and requires
+# pull-requests: read; declare permissions explicitly so the workflow keeps
+# working if the repo/org default token permissions are ever restricted.
+permissions:
+  contents: read
+  pull-requests: read
+
+# Supersede in-flight runs on rapid PR pushes (keep main pushes intact).
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  JAVA_VERSION: 17
+  PYTHON_VERSION: "3.11"
+  SL_VERSION: "1.5.11"
+  SL_ENV: DUCKDB
+  # ---------------------------------------------------------------------
+  # SINGLE EDIT POINT for the test matrix: one JSON object per leg.
+  # Adding an orchestrator version = adding one line; "enabled": false
+  # parks a leg without deleting it (still parsed and JSON-validated on
+  # every run, spawns nothing). Fields:
+  #   name                 → check-name suffix (test-<name>) + uv cache suffix
+  #   module               → path-filter key + install/import-sanity switch
+  #   orchestrator_version → pip pin for the orchestrator ("-" = none; the
+  #                          snowflake SDK comes via install_requires)
+  #   companion            → extra coupled pin (dagster-shell tracks dagster)
+  #   tests                → pytest path(s) for the leg
+  #   enabled              → spawn switch
+  # tests/airflow/ is a DUAL-VERSION suite (compat layer + commit b4ab4da):
+  # BOTH airflow legs run the SAME suite; the Airflow-2-only tests (runtime
+  # suite, TestDatabaseTransport) carry their own skipifs and auto-skip on
+  # the 3.3.0 leg.
+  # ---------------------------------------------------------------------
+  TEST_MATRIX: >-
+    [
+      {"name":"orchestration","module":"orchestration","orchestrator_version":"-","tests":"tests/orchestration/ tests/shared/","enabled":true},
+      {"name":"airflow-2.10.5","module":"airflow","orchestrator_version":"2.10.5","tests":"tests/airflow/","enabled":true},
+      {"name":"airflow-3.3.0","module":"airflow","orchestrator_version":"3.3.0","tests":"tests/airflow/","enabled":true},
+      {"name":"dagster-1.9.13","module":"dagster","orchestrator_version":"1.9.13","companion":"dagster-shell==0.25.13","tests":"tests/dagster/","enabled":true},
+      {"name":"snowflake","module":"snowflake","orchestrator_version":"-","tests":"tests/snowflake/","enabled":true}
+    ]
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      legs: ${{ steps.matrix.outputs.legs }}
+      core_changed: ${{ steps.matrix.outputs.core_changed }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        if: github.event_name != 'workflow_dispatch'
+        id: filter
+        with:
+          filters: |
+            core:
+              - 'starlake-orchestration/src/main/**'
+              - 'tests/shared/**'
+              - 'tests/orchestration/**'
+              - 'tests/sample-project/**'
+              - 'tests/conftest.py'
+              - 'tests/__init__.py'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.env.example'
+              - '.github/workflows/test.yml'
+            airflow:
+              - 'starlake-airflow/src/main/**'
+              - 'tests/airflow/**'
+            dagster:
+              - 'starlake-dagster/src/main/**'
+              - 'tests/dagster/**'
+            snowflake:
+              - 'starlake-snowflake/src/main/**'
+              - 'tests/snowflake/**'
+      # Emits the DOCUMENTED whole-matrix form (GitHub expressions reference,
+      # fromJSON example): output is {"include":[{...},{...}]} consumed as
+      # `matrix: ${{ fromJSON(...) }}`. jq is preinstalled on ubuntu runners.
+      - name: Compute test matrix
+        id: matrix
+        env:
+          CORE: ${{ steps.filter.outputs.core }}
+          AIRFLOW: ${{ steps.filter.outputs.airflow }}
+          DAGSTER: ${{ steps.filter.outputs.dagster }}
+          SNOWFLAKE: ${{ steps.filter.outputs.snowflake }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            CORE=true; AIRFLOW=true; DAGSTER=true; SNOWFLAKE=true
+          fi
+          changed='[]'
+          [ "$CORE" = "true" ] && changed=$(jq -c '. + ["orchestration","airflow","dagster","snowflake"]' <<<"$changed")
+          [ "$AIRFLOW" = "true" ] && changed=$(jq -c '. + ["airflow"]' <<<"$changed")
+          [ "$DAGSTER" = "true" ] && changed=$(jq -c '. + ["dagster"]' <<<"$changed")
+          [ "$SNOWFLAKE" = "true" ] && changed=$(jq -c '. + ["snowflake"]' <<<"$changed")
+          matrix=$(jq -c --argjson changed "$changed" \
+            '{include: [ .[] | select(.enabled) | select(.module as $m | $changed | index($m)) ]}' \
+            <<<"$TEST_MATRIX")
+          legs=$(jq '.include | length' <<<"$matrix")
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "legs=$legs" >> "$GITHUB_OUTPUT"
+          echo "core_changed=${CORE:-false}" >> "$GITHUB_OUTPUT"
+          echo "Test matrix ($legs legs, core_changed=${CORE:-false}): $matrix"
+
+  license-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java and Maven
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+      - name: Check Apache 2.0 license headers (NFR16)
+        run: >
+          mvn -B com.mycila:license-maven-plugin:4.2:check
+          -pl starlake-orchestration,starlake-airflow,starlake-dagster,starlake-snowflake
+
+  test:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.legs != '0' && needs.detect-changes.outputs.legs != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: test-${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      # Whole-matrix form from job output — the documented fromJSON pattern.
+      matrix: ${{ fromJSON(needs.detect-changes.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # This job executes a remote install script (setup.sh below);
+          # never leave the GITHUB_TOKEN in .git/config here.
+          persist-credentials: false
+
+      - name: Set up Java 17 (Starlake CLI runtime)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Set up uv
+        # Pinned per setup-uv README recommendation; hash verified against the
+        # v8.3.2 tag via the GitHub API (2026-07-13)
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+          # Legs install very different wheel sets (airflow 2 vs airflow 3 vs
+          # dagster vs snowflake); without a suffix they contend for one cache
+          # key and only the first leg to finish gets its wheels cached.
+          cache-suffix: ${{ matrix.name }}
+
+      - name: Cache Starlake CLI
+        id: cache-starlake
+        uses: actions/cache@v4
+        with:
+          path: ~/starlake
+          key: starlake-cli-${{ env.SL_VERSION }}-v1
+
+      - name: Install Starlake CLI
+        if: steps.cache-starlake.outputs.cache-hit != 'true'
+        env:
+          ENABLE_ALL: "false"
+          ENABLE_BIGQUERY: "false"
+          ENABLE_AZURE: "false"
+          ENABLE_SNOWFLAKE: "false"
+          ENABLE_REDSHIFT: "false"
+          ENABLE_POSTGRESQL: "false"
+          ENABLE_KAFKA: "false"
+          ENABLE_MARIA: "false"
+          ENABLE_CLICKHOUSE: "false"
+          ENABLE_TRINODB: "false"
+          ENABLE_DUCKDB: "true"
+          ENABLE_API: "false"
+        # -f fails on HTTP errors (a bare `curl | bash` under the default
+        # shell has no pipefail, so a failed download would "succeed" empty);
+        # </dev/null makes any unexpected interactive prompt in setup.jar
+        # fail fast instead of hanging until the job timeout.
+        run: |
+          curl -fsSL -o /tmp/sl-setup.sh https://raw.githubusercontent.com/starlake-ai/starlake/master/distrib/setup.sh
+          bash /tmp/sl-setup.sh --version=${{ env.SL_VERSION }} --target=$HOME/starlake < /dev/null
+
+      - name: Add Starlake CLI to PATH
+        run: echo "$HOME/starlake" >> "$GITHUB_PATH"
+
+      # Fails loudly instead of letting integration tests skip silently; the
+      # grep also catches a stale cache whose installed version no longer
+      # matches SL_VERSION (starlake --version echoes versions.sh, no JVM).
+      - name: Starlake CLI sanity check
+        run: starlake --version | grep -F "${{ env.SL_VERSION }}"
+
+      - name: Create virtual environment
+        run: uv venv --python ${{ env.PYTHON_VERSION }}
+
+      - name: Install test dependencies
+        run: uv pip install -r pyproject.toml --extra test
+
+      # Each module's setup.py does open("README.md") but the per-module
+      # src/main/python/README.md files are NOT tracked in git — Maven's
+      # copy-readme execution creates them at build time. Stage them here
+      # or every editable install below fails with FileNotFoundError.
+      - name: Stage module READMEs (Maven copy-readme equivalent)
+        run: |
+          for m in starlake-orchestration starlake-airflow starlake-dagster starlake-snowflake; do
+            cp "$m/README.md" "$m/src/main/python/README.md"
+          done
+
+      - name: Install local core (module under test, or core changed on this PR)
+        if: matrix.module == 'orchestration' || needs.detect-changes.outputs.core_changed == 'true'
+        run: uv pip install -e starlake-orchestration/src/main/python/
+
+      # Version-parameterized: the orchestrator pin comes from the matrix
+      # entry, not from hardcoded literals. Airflow's official constraints
+      # files are tagged constraints-<AIRFLOW_VERSION>/constraints-<PYTHON>.txt
+      # (verified: both constraints-2.10.5 and constraints-3.3.0 exist for 3.11).
+      - name: Install module under test
+        run: |
+          case "${{ matrix.module }}" in
+            orchestration)
+              echo "core already installed"
+              ;;
+            airflow)
+              uv pip install "apache-airflow==${{ matrix.orchestrator_version }}" \
+                --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${{ matrix.orchestrator_version }}/constraints-${{ env.PYTHON_VERSION }}.txt"
+              uv pip install -e starlake-airflow/src/main/python/
+              ;;
+            dagster)
+              uv pip install "dagster==${{ matrix.orchestrator_version }}" "${{ matrix.companion }}"
+              uv pip install -e starlake-dagster/src/main/python/
+              ;;
+            snowflake)
+              uv pip install -e starlake-snowflake/src/main/python/
+              ;;
+            *)
+              echo "Unknown matrix module: ${{ matrix.module }}" >&2
+              exit 1
+              ;;
+          esac
+
+      # Guards against fake-green runs: a broken install would otherwise make
+      # the availability skip-guards (or collection errors) hide the problem.
+      - name: Module import sanity check
+        run: |
+          case "${{ matrix.module }}" in
+            orchestration) uv run --no-sync python -c "import ai.starlake.orchestration" ;;
+            airflow)       uv run --no-sync python -c "import airflow, ai.starlake.airflow" ;;
+            dagster)       uv run --no-sync python -c "import dagster, dagster_shell, ai.starlake.dagster" ;;
+            snowflake)     uv run --no-sync python -c "import snowflake.core, ai.starlake.snowflake" ;;
+          esac
+
+      # The pytest target comes from the matrix entry. Both airflow legs run
+      # the dual-version tests/airflow/ suite; on 3.3.0 the Airflow-2-only
+      # tests (runtime suite, TestDatabaseTransport) auto-skip — -ra prints
+      # every skip reason so the expected v3 skips stay auditable.
+      - name: Run tests
+        run: uv run --no-sync pytest ${{ matrix.tests }} -v -ra --durations=15
+
+  # Stable, always-present check name for branch protection: the dynamic
+  # matrix means test-<name> checks exist only when that module changed
+  # (and the leg is enabled), so THIS is the job to mark as a required
+  # status check (never the legs).
+  tests-passed:
+    needs: [detect-changes, test, license-check]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail if any upstream job failed or was cancelled
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "Upstream job failed or was cancelled" >&2
+            exit 1
+          fi
+          echo "All upstream jobs succeeded or were skipped"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ test = [
     "duckdb>=0.9.0",
     "pyyaml>=6.0",
     "python-dotenv>=1.0",
+    "jinja2>=3.0",
 ]
 
 [tool.pytest.ini_options]

--- a/starlake-orchestration/src/main/python/setup.py
+++ b/starlake-orchestration/src/main/python/setup.py
@@ -21,6 +21,7 @@ setup(name='starlake-orchestration',
       license='Apache 2.0',
 #      url='https://github.com/starlake-ai/starlake/tree/master/src/main/python/starlake-orchestration',
       packages=find_packages(include=['ai', 'ai.*']),
+      install_requires=['croniter'],
       extras_require={
         "airflow": ["starlake-airflow~=0.4"],
         "dagster": ["starlake-dagster~=0.4"],

--- a/starlake-orchestration/src/main/python/setup.py
+++ b/starlake-orchestration/src/main/python/setup.py
@@ -21,7 +21,7 @@ setup(name='starlake-orchestration',
       license='Apache 2.0',
 #      url='https://github.com/starlake-ai/starlake/tree/master/src/main/python/starlake-orchestration',
       packages=find_packages(include=['ai', 'ai.*']),
-      install_requires=['croniter'],
+      install_requires=['croniter', 'python-dateutil', 'pytz'],
       extras_require={
         "airflow": ["starlake-airflow~=0.4"],
         "dagster": ["starlake-dagster~=0.4"],

--- a/starlake-snowflake/src/main/python/ai/starlake/snowflake/starlake_snowflake_job.py
+++ b/starlake-snowflake/src/main/python/ai/starlake/snowflake/starlake_snowflake_job.py
@@ -215,6 +215,10 @@ class StarlakeSnowflakeJob(IStarlakeJob[DAGTask, StarlakeDataset], StarlakeOptio
         Returns:
             DAGTask: The Snowflake task.
         """
+        # Snowflake tasks have no lineage-input concept and DAGTask's
+        # constructor is strict; dataset-driven triggering is handled by the
+        # module's event mechanism instead.
+        kwargs.pop('inlets', None)
         comment = kwargs.get('comment', None)
         if not comment:
             comment = f"Starlake load {domain}.{table}"
@@ -249,6 +253,9 @@ class StarlakeSnowflakeJob(IStarlakeJob[DAGTask, StarlakeDataset], StarlakeOptio
         Returns:
             DAGTask: The Snowflake task.
         """
+        # Same rationale as sl_load: consume the lineage kwarg before it
+        # reaches DAGTask's strict constructor.
+        kwargs.pop('inlets', None)
         if dataset:
             if isinstance(dataset, str):
                 sink = dataset

--- a/tests/airflow/test_airflow_runtime.py
+++ b/tests/airflow/test_airflow_runtime.py
@@ -14,16 +14,27 @@
 # limitations under the License.
 #
 
-"""Airflow 2 runtime integration tests.
+"""Airflow runtime integration tests (dual-version: Airflow 2 and 3).
 
 These tests actually execute DAGs through Airflow's ``dag.test()`` engine,
-validate data in DuckDB, verify Airflow Dataset outlet event production,
-and test transform DAG triggering with ANY / ALL strategies.
+validate data in DuckDB, verify Dataset/Asset outlet production, and test
+transform DAG triggering with ANY / ALL strategies.
+
+Version divergence is confined to module level:
+
+- Airflow 2 names (``Dataset``/``DatasetAll``/``DatasetAny``,
+  ``timetable.dataset_condition``, ``dag.test(execution_date=...)``) map to
+  Airflow 3 assets (``Asset``/``AssetAll``/``AssetAny``,
+  ``timetable.asset_condition``, ``dag.test(logical_date=...)``).
+- DAG registration: Airflow 2 requires ``DAG.bulk_write_to_db``; Airflow 3's
+  ``dag.test()`` self-syncs the owning DAG bundle — the fixtures configure
+  an explicit ``LocalDagBundle`` over the generated DAGs directory via
+  ``AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST``.
 
 All heavy operations (dag-generate, load_pipelines, dag.test) are
 module-scoped to avoid redundant JVM startups.
 
-Prerequisites: Apache Airflow 2.x, Starlake CLI, Java 17+.
+Prerequisites: Apache Airflow 2.x or 3.x, Starlake CLI, Java 17+.
 """
 
 from __future__ import annotations
@@ -36,31 +47,120 @@ from tests.shared.conftest import get_duckdb, restore_env, set_env
 
 try:
     import airflow
-    from airflow.datasets import Dataset, DatasetAll, DatasetAny
-    from airflow.models.dag import DAG
-    from airflow.models.dataset import DatasetEvent, DatasetModel
-    from airflow.utils.state import DagRunState
 
     AIRFLOW_AVAILABLE = True
     AIRFLOW_VERSION = tuple(int(x) for x in airflow.__version__.split(".")[:2])
+    SUPPORTS_ASSETS = AIRFLOW_VERSION >= (3, 0)
+    if SUPPORTS_ASSETS:
+        from airflow.sdk import Asset as Dataset
+        from airflow.sdk import AssetAll as DatasetAll
+        from airflow.sdk import AssetAny as DatasetAny
+    else:
+        from airflow.datasets import Dataset, DatasetAll, DatasetAny
+    from airflow.models.dag import DAG
+    from airflow.utils.state import DagRunState
 except ImportError:
     AIRFLOW_AVAILABLE = False
     AIRFLOW_VERSION = (0, 0)
+    SUPPORTS_ASSETS = False
 
 pytestmark = [
     pytest.mark.integration,
     pytest.mark.skipif(
-        not AIRFLOW_AVAILABLE or AIRFLOW_VERSION >= (3, 0),
-        reason="Runtime suite is Airflow 2 only for now: it seeds "
-        "DatasetModel/DatasetEvent directly in the metadata database "
-        "(porting to Airflow 3 assets pending)",
+        not AIRFLOW_AVAILABLE,
+        reason="Requires Apache Airflow",
     ),
 ]
+
+# The name of the condition attribute on dataset/asset-triggered timetables.
+_CONDITION_ATTR = "asset_condition" if SUPPORTS_ASSETS else "dataset_condition"
 
 # Use "now" as execution date — the DAG's start_date is derived from
 # the generated file's mtime, which is always "today".  An execution
 # date in the past would cause Airflow to skip all tasks.
 EXECUTION_DATE = datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def _runtime_env(env, dags_dir):
+    """Return the process env for runtime fixtures (version-aware).
+
+    On Airflow 3, ``dag.test()`` registers DAGs by syncing the owning DAG
+    bundle, which parses the bundle's path — point it at the generated DAGs
+    directory.  The bundle path must be given EXPLICITLY in the bundle
+    config: with no ``path`` kwarg, ``LocalDagBundle`` falls back to
+    ``settings.DAGS_FOLDER``, a constant frozen when ``airflow.settings``
+    was first imported, which no ``dags_folder`` override can reach.
+    On Airflow 2 registration is explicit (``DAG.bulk_write_to_db``) and
+    the bundle machinery does not exist.
+    """
+    e = dict(env)
+    # Isolate the metadata DB per session AND per major version.  The
+    # unit-test config's default (unittests.db under the import-time
+    # AIRFLOW_HOME) is shared state: an Airflow 3 run migrates it to the
+    # 3.x schema and a subsequent Airflow 2 run then fails on the renamed
+    # columns (and vice versa).  Env vars beat the test-config file layer,
+    # so this wins over load_test_config's value.
+    e["AIRFLOW__DATABASE__SQL_ALCHEMY_CONN"] = (
+        f"sqlite:///{dags_dir.parent}/airflow_v{AIRFLOW_VERSION[0]}_metadata.db"
+    )
+    if SUPPORTS_ASSETS:
+        import json
+
+        e["AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST"] = json.dumps([
+            {
+                "name": "dags-folder",
+                "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
+                "kwargs": {"path": str(dags_dir)},
+            }
+        ])
+    return e
+
+
+def _init_airflow_db():
+    """Load the test config and initialize the metadata database.
+
+    ``settings.configure_orm()`` must be re-run after the config change:
+    the engine was built at import time from the pre-fixture config, so
+    without it ``initdb`` (and everything after) would keep talking to
+    the import-time database, ignoring the per-version connection set in
+    :func:`_runtime_env`.
+    """
+    from airflow.configuration import initialize_config
+
+    initialize_config().load_test_config()
+
+    from airflow import settings
+
+    settings.configure_vars()
+    settings.configure_orm()
+
+    from airflow.utils.db import initdb
+
+    initdb()
+
+
+def _register_dags(pipelines):
+    """Register pipeline DAGs in the metadata DB (Airflow 2 only).
+
+    ``DAG.bulk_write_to_db`` no longer exists on Airflow 3, where
+    ``dag.test()`` self-syncs the DAG bundle from the dags folder.
+    """
+    if not SUPPORTS_ASSETS:
+        DAG.bulk_write_to_db([p.dag for p in pipelines])
+
+
+def _dag_test(dag):
+    """Run ``dag.test()`` with version-appropriate kwargs.
+
+    Airflow 3 renamed ``execution_date`` to ``logical_date`` and serializes
+    ``run_conf`` as strict JSON — pass the start date as an ISO string there
+    (the same shape a REST-triggered run's conf has in production).
+    """
+    if SUPPORTS_ASSETS:
+        run_conf = {"start_date": EXECUTION_DATE.isoformat(), "backfill": False}
+        return dag.test(logical_date=EXECUTION_DATE, run_conf=run_conf)
+    run_conf = {"start_date": EXECUTION_DATE, "backfill": False}
+    return dag.test(execution_date=EXECUTION_DATE, run_conf=run_conf)
 
 
 # ===================================================================
@@ -71,12 +171,9 @@ EXECUTION_DATE = datetime.now(timezone.utc).replace(microsecond=0)
 def load_pipelines_loaded(runtime_dags, airflow_home):
     """Load generated load DAGs and register them in Airflow metadata DB."""
     dags_dir, isolated, env = runtime_dags
-    orig = set_env(env)
+    orig = set_env(_runtime_env(env, dags_dir))
     try:
-        from airflow.configuration import initialize_config
-        initialize_config().load_test_config()
-        from airflow.utils.db import initdb
-        initdb()
+        _init_airflow_db()
 
         from ai.starlake.orchestration.__main__ import load_pipelines
 
@@ -86,8 +183,7 @@ def load_pipelines_loaded(runtime_dags, airflow_home):
             if r:
                 pls.extend(r)
         assert pls, "No load pipelines found"
-        for p in pls:
-            DAG.bulk_write_to_db([p.dag])
+        _register_dags(pls)
         return pls, isolated, env
     finally:
         restore_env(orig)
@@ -97,12 +193,9 @@ def load_pipelines_loaded(runtime_dags, airflow_home):
 def transform_pipelines_loaded(runtime_dags, airflow_home):
     """Load generated transform DAGs and register in Airflow metadata DB."""
     dags_dir, isolated, env = runtime_dags
-    orig = set_env(env)
+    orig = set_env(_runtime_env(env, dags_dir))
     try:
-        from airflow.configuration import initialize_config
-        initialize_config().load_test_config()
-        from airflow.utils.db import initdb
-        initdb()
+        _init_airflow_db()
 
         from ai.starlake.orchestration.__main__ import load_pipelines
 
@@ -112,31 +205,25 @@ def transform_pipelines_loaded(runtime_dags, airflow_home):
             if r:
                 pls.extend(r)
         assert pls, "No transform pipelines found"
-        for p in pls:
-            DAG.bulk_write_to_db([p.dag])
+        _register_dags(pls)
         return pls, isolated, env
     finally:
         restore_env(orig)
 
 
 @pytest.fixture(scope="module")
-def executed_load_dags(load_pipelines_loaded):
+def executed_load_dags(runtime_dags, load_pipelines_loaded):
     """Execute all load DAGs once via dag.test() — shared by load tests."""
+    dags_dir, _, _ = runtime_dags
     pls, isolated, env = load_pipelines_loaded
-    orig = set_env(env)
+    orig = set_env(_runtime_env(env, dags_dir))
     try:
-        from airflow.configuration import initialize_config
-        initialize_config().load_test_config()
-        from airflow.utils.db import initdb
-        initdb()
+        _init_airflow_db()
 
         results = []
         for p in pls:
 
-            run_conf = {"start_date": EXECUTION_DATE, "backfill": False}
-            dr = p.dag.test(
-                execution_date=EXECUTION_DATE, run_conf=run_conf
-            )
+            dr = _dag_test(p.dag)
             results.append((p, dr))
         return results, isolated, env
     finally:
@@ -144,24 +231,19 @@ def executed_load_dags(load_pipelines_loaded):
 
 
 @pytest.fixture(scope="module")
-def executed_transform_dags(executed_load_dags, transform_pipelines_loaded):
+def executed_transform_dags(runtime_dags, executed_load_dags, transform_pipelines_loaded):
     """Execute all transform DAGs after load — shared by transform tests."""
+    dags_dir, _, _ = runtime_dags
     _, isolated, env = executed_load_dags
     pls, _, _ = transform_pipelines_loaded
-    orig = set_env(env)
+    orig = set_env(_runtime_env(env, dags_dir))
     try:
-        from airflow.configuration import initialize_config
-        initialize_config().load_test_config()
-        from airflow.utils.db import initdb
-        initdb()
+        _init_airflow_db()
 
         results = []
         for p in pls:
 
-            run_conf = {"start_date": EXECUTION_DATE, "backfill": False}
-            dr = p.dag.test(
-                execution_date=EXECUTION_DATE, run_conf=run_conf
-            )
+            dr = _dag_test(p.dag)
             results.append((p, dr))
         return results, isolated, env
     finally:
@@ -206,7 +288,7 @@ class TestAirflowRuntimeLoad:
             conn.close()
 
     def test_load_tasks_produce_dataset_outlets(self, load_pipelines_loaded):
-        """Load tasks declare outlet Datasets for each table.
+        """Load tasks declare outlet Datasets/Assets for each table.
 
         Outlets are collected across ALL load pipelines (daily + hourly)
         since tables are split by schedule frequency.
@@ -267,34 +349,35 @@ class TestAirflowRuntimeTransform:
 # ===================================================================
 
 class TestAirflowDatasetTriggering:
-    """Verify transform DAG dataset-triggered scheduling with ANY / ALL."""
+    """Verify transform DAG dataset/asset-triggered scheduling with ANY / ALL."""
 
     def test_transform_dag_uses_dataset_triggered_timetable(
         self, transform_pipelines_loaded
     ):
-        """Generated transform DAG has a DatasetTriggeredTimetable."""
+        """Generated transform DAG has a Dataset/AssetTriggeredTimetable."""
         pls, _, _ = transform_pipelines_loaded
+        expected_marker = "Asset" if SUPPORTS_ASSETS else "Dataset"
         for pipeline in pls:
             timetable_cls = type(pipeline.dag.timetable).__name__
-            assert "Dataset" in timetable_cls, (
-                f"Expected dataset timetable, got {timetable_cls}"
+            assert expected_marker in timetable_cls, (
+                f"Expected {expected_marker.lower()} timetable, got {timetable_cls}"
             )
             assert len(pipeline.events) > 0, (
                 f"Pipeline {pipeline.pipeline_id} has no dataset events"
             )
 
     def test_any_strategy_uses_or_combination(self, transform_pipelines_loaded):
-        """Default strategy (ANY) builds dataset_condition with DatasetAny."""
+        """Default strategy (ANY) builds the condition with DatasetAny/AssetAny."""
         pls, _, _ = transform_pipelines_loaded
         for pipeline in pls:
             timetable = pipeline.dag.timetable
-            assert hasattr(timetable, "dataset_condition"), (
-                f"Timetable {type(timetable).__name__} has no dataset_condition"
+            assert hasattr(timetable, _CONDITION_ATTR), (
+                f"Timetable {type(timetable).__name__} has no {_CONDITION_ATTR}"
             )
-            condition = timetable.dataset_condition
+            condition = getattr(timetable, _CONDITION_ATTR)
             if len(pipeline.events) > 1:
                 assert isinstance(condition, DatasetAny), (
-                    f"Expected DatasetAny for ANY strategy, "
+                    f"Expected {DatasetAny.__name__} for ANY strategy, "
                     f"got {type(condition).__name__}"
                 )
                 condition_uris = {d.uri for d in condition.objects}
@@ -304,7 +387,7 @@ class TestAirflowDatasetTriggering:
                 )
 
     def test_all_strategy_uses_and_combination(self, airflow_home):
-        """ALL strategy builds dataset_condition with DatasetAll (AND)."""
+        """ALL strategy builds the condition with DatasetAll/AssetAll (AND)."""
         from ai.starlake.airflow import AirflowOrchestration
         from ai.starlake.airflow.bash import StarlakeAirflowBashJob
         from ai.starlake.orchestration import (
@@ -343,11 +426,12 @@ class TestAirflowDatasetTriggering:
             pass
 
         timetable = pipeline.dag.timetable
-        assert hasattr(timetable, "dataset_condition")
-        condition = timetable.dataset_condition
+        assert hasattr(timetable, _CONDITION_ATTR)
+        condition = getattr(timetable, _CONDITION_ATTR)
 
         assert isinstance(condition, DatasetAll), (
-            f"Expected DatasetAll for ALL strategy, got {type(condition).__name__}"
+            f"Expected {DatasetAll.__name__} for ALL strategy, "
+            f"got {type(condition).__name__}"
         )
         condition_uris = {d.uri for d in condition.objects}
         assert "starbake_orders" in condition_uris


### PR DESCRIPTION
## Summary

Adds `.github/workflows/test.yml` — a path-filtered CI test pipeline (no existing workflow touched):

- **detect-changes**: `dorny/paths-filter@v3` classifies changes into core / airflow / dagster / snowflake; a jq step computes a dynamic `fromJSON` matrix from the workflow-level `env.TEST_MATRIX` JSON (single edit point for orchestrator version pins).
- **test** (matrix, `fail-fast: false`): five enabled legs — `orchestration`, `airflow-2.10.5`, `airflow-3.3.0` (both run the dual-version `tests/airflow/` suite; Airflow-2-only tests auto-skip on 3.x), `dagster-1.9.13`, `snowflake`. Only the affected legs spawn; core changes spawn all.
- **Dependency-version testing**: orchestrator legs install their *declared* core specifier from PyPI unless core changed on the PR (then local core is pre-installed and wins). Installs are **non-editable** — the `ai.starlake` namespace is made of regular packages, so editable installs shadow each other; regular installs merge, matching what PyPI users get.
- **Starlake CLI 1.5.11** provisioned non-interactively (DuckDB-only slim install) with `actions/cache`; loud sanity checks (CLI version grep + per-leg import checks) prevent fake-green runs via skip guards.
- **license-check**: always-on `mvn license:check` scoped to the four modules (NFR16).
- **tests-passed**: stable join job — the only check name safe to mark required under a dynamic matrix.

### Framework bugs surfaced and fixed by the new pipeline (dependency isolation doing its job)

- **#59** — core wheel declared **no** runtime dependencies while importing `croniter`, `dateutil`, `pytz` at module level (masked transitively by every orchestrator; Airflow 3 drops pytz). Fixed: `install_requires=['croniter', 'python-dateutil', 'pytz']`.
- **#60** — snowflake module forwarded the core's `inlets` kwarg into `snowflake.core`'s strict `DAGTask` constructor → every Snowflake load/transform pipeline failed to build (masked locally by stale dev-venv core wheels). Fixed: both overrides consume `inlets` on entry.
- `jinja2` added to the `test` extra (template tests import it directly; only the snowflake leg didn't inherit it).

Closes #44. Closes #57 (final story of the test-suite epic). Closes #59. Closes #60.

> Note: this PR targets `feature/sl-options-events` (the test suites and compat layer live there, not yet on `main`), so GitHub auto-closes these issues only when that branch merges to `main`.

## NFR10 evidence (per-leg < 5 min) — run [29307141992](https://github.com/starlake-ai/starlake-orchestration/actions/runs/29307141992) (all green, warm caches)

| Job | Wall time | Pytest result |
|---|---|---|
| detect-changes | 7 s | — |
| license-check | 9 s | — |
| test-orchestration | 28 s | 114 passed |
| test-snowflake | 45 s | 61 passed, 7 xfailed |
| test-airflow-3.3.0 | 48 s | 108 passed, 16 skipped (expected v3 delta: runtime suite + TestDatabaseTransport — exactly the documented set) |
| test-dagster-1.9.13 | 1 m 41 s | 85 passed |
| test-airflow-2.10.5 | 1 m 55 s | 124 passed (runtime suite included) |
| tests-passed | 3 s | — |

Cold-cache penalty (first run after an `SL_VERSION` bump): +2–4 min for the Starlake CLI install — still under the 5-minute budget.

### Remaining post-merge validation (needs the workflow on the default branch)

- `workflow_dispatch` full-matrix button (dispatch requires the workflow file on `main`).
- A snowflake-only PR to observe single-leg spawning + PyPI-core resolution (`~=0.4` is published; airflow/dagster `~=0.5` resolves from PyPI only once core 0.5.0 is published).
- Branch protection: mark **`tests-passed`** (and nothing else) as the required status check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)