### PR TITLE
Story 3.1 — Cross-orchestrator lineage graph consumption validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,11 @@
 
 SL_VERSION=1.5.11
 SL_ENV=DUCKDB
+# Secondary Starlake CLI version for NFR7 version-tolerance tests.
+# Install with:
+#   curl -sSL https://raw.githubusercontent.com/starlake-ai/starlake/master/distrib/setup.sh \
+#     | bash -s -- --version=1.5.15 --target=$HOME/starlake-1.5.15
+# Tests skip when ~/starlake-<version>/starlake is absent.
+SL_VERSION_SECONDARY=1.5.15
 # Set JAVA_HOME to your Java 17 installation path (uncomment and adjust)
 # JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ env:
   JAVA_VERSION: 17
   PYTHON_VERSION: "3.11"
   SL_VERSION: "1.5.11"
+  # Secondary CLI for the NFR7 version-tolerance test (orchestration leg only).
+  SL_VERSION_SECONDARY: "1.5.15"
   SL_ENV: DUCKDB
   # ---------------------------------------------------------------------
   # SINGLE EDIT POINT for the test matrix: one JSON object per leg.
@@ -204,6 +206,46 @@ jobs:
       # matches SL_VERSION (starlake --version echoes versions.sh, no JVM).
       - name: Starlake CLI sanity check
         run: starlake --version | grep -F "${{ env.SL_VERSION }}"
+
+      # ----------------------------------------------------------------
+      # Secondary Starlake CLI (NFR7 version tolerance) — orchestration
+      # leg only: the dual-CLI lineage test lives in tests/shared/, which
+      # only that leg runs. Separate install target keyed by version:
+      # starlake.sh selects the jar via SL_VERSION and never downloads on
+      # demand, so SL_VERSION-switching inside one install cannot work.
+      # ----------------------------------------------------------------
+      - name: Cache secondary Starlake CLI (NFR7)
+        if: matrix.module == 'orchestration'
+        id: cache-starlake-secondary
+        uses: actions/cache@v4
+        with:
+          path: ~/starlake-${{ env.SL_VERSION_SECONDARY }}
+          key: starlake-cli-${{ env.SL_VERSION_SECONDARY }}-v1
+
+      - name: Install secondary Starlake CLI (NFR7)
+        if: matrix.module == 'orchestration' && steps.cache-starlake-secondary.outputs.cache-hit != 'true'
+        env:
+          ENABLE_ALL: "false"
+          ENABLE_BIGQUERY: "false"
+          ENABLE_AZURE: "false"
+          ENABLE_SNOWFLAKE: "false"
+          ENABLE_REDSHIFT: "false"
+          ENABLE_POSTGRESQL: "false"
+          ENABLE_KAFKA: "false"
+          ENABLE_MARIA: "false"
+          ENABLE_CLICKHOUSE: "false"
+          ENABLE_TRINODB: "false"
+          ENABLE_DUCKDB: "true"
+          ENABLE_API: "false"
+        run: |
+          curl -fsSL -o /tmp/sl-setup-secondary.sh https://raw.githubusercontent.com/starlake-ai/starlake/master/distrib/setup.sh
+          bash /tmp/sl-setup-secondary.sh --version=${{ env.SL_VERSION_SECONDARY }} --target=$HOME/starlake-${{ env.SL_VERSION_SECONDARY }} < /dev/null
+
+      - name: Secondary Starlake CLI sanity check (NFR7)
+        if: matrix.module == 'orchestration'
+        # SL_VERSION must be overridden: starlake --version echoes $SL_VERSION
+        # (starlake.sh:369), and the workflow env pins it to the PRIMARY version.
+        run: SL_VERSION=${{ env.SL_VERSION_SECONDARY }} "$HOME/starlake-${{ env.SL_VERSION_SECONDARY }}/starlake" --version | grep -F "${{ env.SL_VERSION_SECONDARY }}"
 
       - name: Create virtual environment
         run: uv venv --python ${{ env.PYTHON_VERSION }}

--- a/tests/airflow/test_airflow_lineage.py
+++ b/tests/airflow/test_airflow_lineage.py
@@ -1,0 +1,126 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import pytest
+
+from tests.shared.lineage_utils import (
+    EXPECTED_LOAD_TRIPLES,
+    EXPECTED_TRANSFORM_EDGES,
+    EXPECTED_TRANSFORM_NODES,
+    extract_embedded_lineage,
+    is_transform_dag,
+    normalize_lineage,
+    normalize_load_schedules,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+
+@pytest.fixture(scope="module")
+def generated_python_files(runtime_dags):
+    """All generated .py DAG files (same fixture shape as the integration tests)."""
+    dags_dir, _, _ = runtime_dags
+    files = sorted(dags_dir.glob("*.py"))
+    assert len(files) > 0, f"No .py files in {dags_dir}"
+    return files
+
+
+@pytest.fixture(scope="module")
+def transform_pipelines(generated_python_files, runtime_env_vars):
+    """Load the (single) generated transform DAG through load_pipelines()."""
+    from ai.starlake.orchestration.__main__ import load_pipelines
+
+    transform_files = [f for f in generated_python_files if is_transform_dag(f)]
+    assert len(transform_files) == 1, (
+        f"Expected exactly one transform DAG, got: {[f.name for f in transform_files]}"
+    )
+    pipelines = load_pipelines(str(transform_files[0]))
+    assert pipelines, "No pipelines loaded from the transform DAG"
+    return pipelines
+
+
+class TestAirflowLineageConsumption:
+
+    # -- AC #1 / #3: CLI → template seam -------------------------------------
+
+    def test_embedded_lineage_matches_canonical_graph(self, generated_python_files):
+        """The CLI-computed lineage JSON embedded in the generated transform DAG
+        normalizes to the canonical graph shared by every orchestrator."""
+        transform_files = [f for f in generated_python_files if is_transform_dag(f)]
+        assert len(transform_files) == 1
+        normalized = normalize_lineage(extract_embedded_lineage(transform_files[0]))
+        assert normalized["nodes"] == EXPECTED_TRANSFORM_NODES
+        assert normalized["edges"] == EXPECTED_TRANSFORM_EDGES
+
+    # -- AC #1 / #3: template → framework seam -------------------------------
+
+    def test_transform_pipeline_dependency_structure(self, transform_pipelines):
+        """load_pipelines() yields the same logical task graph on every orchestrator."""
+        assert len(transform_pipelines) == 1
+        pipeline = transform_pipelines[0]
+
+        # CLI emits cron="None" (string); the framework must normalize it to None
+        assert pipeline.cron is None
+
+        # graphs: with load_dependencies=False only kpi.top_customers is a root
+        # graph, its filtered parents == {kpi.order_summary}
+        graphs = pipeline.graphs
+        assert graphs is not None
+        assert {g.id for g in graphs} == {"kpi.top_customers"}
+        (graph,) = tuple(graphs)
+        assert {p.id for p in graph.parents} == {"kpi.order_summary"}
+
+        # framework task graph — upstream_dependencies[A] lists A's DOWNSTREAMS
+        assert "kpi_top_customers_task" in pipeline.upstream_dependencies.get(
+            "kpi_order_summary_task", []
+        )
+        assert "kpi_order_summary_task" in pipeline.downstream_dependencies.get(
+            "kpi_top_customers_task", []
+        )
+        for task_id in ("kpi_order_summary_task", "kpi_top_customers_task"):
+            assert task_id in pipeline.tasks_names
+
+    # -- AC #2: sl_load() → sl_transform() lineage preservation --------------
+
+    def test_load_to_transform_lineage_preserved(self, generated_python_files):
+        """Every table node in the transform lineage is exactly a table the load
+        DAGs cover — the load → transform chain is closed."""
+        transform_files = [f for f in generated_python_files if is_transform_dag(f)]
+        lineage = normalize_lineage(extract_embedded_lineage(transform_files[0]))
+        table_nodes = {n for n, typ in lineage["nodes"].items() if typ == "table"}
+        load_tables = {f"{d}.{t}" for (_, d, t) in EXPECTED_LOAD_TRIPLES}
+        assert table_nodes == load_tables
+
+    # -- AC #1 / #3: load-side logical surface --------------------------------
+
+    def test_load_pipelines_cover_canonical_tables(
+        self, generated_python_files, runtime_env_vars
+    ):
+        """All load pipelines together cover exactly the canonical
+        {(cron, domain, table)} set — file layout may differ per orchestrator
+        (Snowflake generates one DAG per table), the logical surface may not."""
+        from ai.starlake.orchestration.__main__ import load_pipelines
+
+        load_files = [f for f in generated_python_files if not is_transform_dag(f)]
+        assert load_files, "No load DAGs generated"
+        pipelines = []
+        for f in load_files:
+            pipelines.extend(load_pipelines(str(f)) or [])
+        assert normalize_load_schedules(pipelines) == EXPECTED_LOAD_TRIPLES

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,12 +32,14 @@ from tests.shared.conftest import (  # noqa: F401
     sl_root_env,
     sample_project_path,
     starlake_cli,
+    starlake_cli_secondary,
     java_home,
     starlake_env,
     duckdb_connection,
     isolated_project,
     runtime_env,
     runtime_dags,
+    runtime_env_vars,
 )
 
 

--- a/tests/dagster/test_dagster_lineage.py
+++ b/tests/dagster/test_dagster_lineage.py
@@ -1,0 +1,126 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import pytest
+
+from tests.shared.lineage_utils import (
+    EXPECTED_LOAD_TRIPLES,
+    EXPECTED_TRANSFORM_EDGES,
+    EXPECTED_TRANSFORM_NODES,
+    extract_embedded_lineage,
+    is_transform_dag,
+    normalize_lineage,
+    normalize_load_schedules,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+
+@pytest.fixture(scope="module")
+def generated_python_files(runtime_dags):
+    """All generated .py DAG files (same fixture shape as the integration tests)."""
+    dags_dir, _, _ = runtime_dags
+    files = sorted(dags_dir.glob("*.py"))
+    assert len(files) > 0, f"No .py files in {dags_dir}"
+    return files
+
+
+@pytest.fixture(scope="module")
+def transform_pipelines(generated_python_files, runtime_env_vars):
+    """Load the (single) generated transform DAG through load_pipelines()."""
+    from ai.starlake.orchestration.__main__ import load_pipelines
+
+    transform_files = [f for f in generated_python_files if is_transform_dag(f)]
+    assert len(transform_files) == 1, (
+        f"Expected exactly one transform DAG, got: {[f.name for f in transform_files]}"
+    )
+    pipelines = load_pipelines(str(transform_files[0]))
+    assert pipelines, "No pipelines loaded from the transform DAG"
+    return pipelines
+
+
+class TestDagsterLineageConsumption:
+
+    # -- AC #1 / #3: CLI → template seam -------------------------------------
+
+    def test_embedded_lineage_matches_canonical_graph(self, generated_python_files):
+        """The CLI-computed lineage JSON embedded in the generated transform DAG
+        normalizes to the canonical graph shared by every orchestrator."""
+        transform_files = [f for f in generated_python_files if is_transform_dag(f)]
+        assert len(transform_files) == 1
+        normalized = normalize_lineage(extract_embedded_lineage(transform_files[0]))
+        assert normalized["nodes"] == EXPECTED_TRANSFORM_NODES
+        assert normalized["edges"] == EXPECTED_TRANSFORM_EDGES
+
+    # -- AC #1 / #3: template → framework seam -------------------------------
+
+    def test_transform_pipeline_dependency_structure(self, transform_pipelines):
+        """load_pipelines() yields the same logical task graph on every orchestrator."""
+        assert len(transform_pipelines) == 1
+        pipeline = transform_pipelines[0]
+
+        # CLI emits cron="None" (string); the framework must normalize it to None
+        assert pipeline.cron is None
+
+        # graphs: with load_dependencies=False only kpi.top_customers is a root
+        # graph, its filtered parents == {kpi.order_summary}
+        graphs = pipeline.graphs
+        assert graphs is not None
+        assert {g.id for g in graphs} == {"kpi.top_customers"}
+        (graph,) = tuple(graphs)
+        assert {p.id for p in graph.parents} == {"kpi.order_summary"}
+
+        # framework task graph — upstream_dependencies[A] lists A's DOWNSTREAMS
+        assert "kpi_top_customers_task" in pipeline.upstream_dependencies.get(
+            "kpi_order_summary_task", []
+        )
+        assert "kpi_order_summary_task" in pipeline.downstream_dependencies.get(
+            "kpi_top_customers_task", []
+        )
+        for task_id in ("kpi_order_summary_task", "kpi_top_customers_task"):
+            assert task_id in pipeline.tasks_names
+
+    # -- AC #2: sl_load() → sl_transform() lineage preservation --------------
+
+    def test_load_to_transform_lineage_preserved(self, generated_python_files):
+        """Every table node in the transform lineage is exactly a table the load
+        DAGs cover — the load → transform chain is closed."""
+        transform_files = [f for f in generated_python_files if is_transform_dag(f)]
+        lineage = normalize_lineage(extract_embedded_lineage(transform_files[0]))
+        table_nodes = {n for n, typ in lineage["nodes"].items() if typ == "table"}
+        load_tables = {f"{d}.{t}" for (_, d, t) in EXPECTED_LOAD_TRIPLES}
+        assert table_nodes == load_tables
+
+    # -- AC #1 / #3: load-side logical surface --------------------------------
+
+    def test_load_pipelines_cover_canonical_tables(
+        self, generated_python_files, runtime_env_vars
+    ):
+        """All load pipelines together cover exactly the canonical
+        {(cron, domain, table)} set — file layout may differ per orchestrator
+        (Snowflake generates one DAG per table), the logical surface may not."""
+        from ai.starlake.orchestration.__main__ import load_pipelines
+
+        load_files = [f for f in generated_python_files if not is_transform_dag(f)]
+        assert load_files, "No load DAGs generated"
+        pipelines = []
+        for f in load_files:
+            pipelines.extend(load_pipelines(str(f)) or [])
+        assert normalize_load_schedules(pipelines) == EXPECTED_LOAD_TRIPLES

--- a/tests/shared/conftest.py
+++ b/tests/shared/conftest.py
@@ -43,6 +43,7 @@ _DOT_ENV = dotenv_values(_DOT_ENV_PATH) if _DOT_ENV_PATH.is_file() else dotenv_v
 _DEFAULTS = {
     "SL_VERSION": "1.5.11",
     "SL_ENV": "DUCKDB",
+    "SL_VERSION_SECONDARY": "1.5.15",
 }
 
 
@@ -104,6 +105,28 @@ def starlake_cli() -> str:
     if cli_path is None:
         pytest.skip("Starlake CLI not found on PATH or at ~/starlake/starlake")
     return cli_path
+
+
+@pytest.fixture(scope="session")
+def starlake_cli_secondary() -> str:
+    """Secondary Starlake CLI for NFR7 version-tolerance tests.
+
+    Expected at ``~/starlake-{SL_VERSION_SECONDARY}/starlake`` (scripted
+    install: ``setup.sh --version=<v> --target=$HOME/starlake-<v>``).
+    Skips when absent — same skip-not-fail contract as ``starlake_cli``;
+    CI installs it explicitly on the orchestration leg plus a sanity check
+    so a silent skip cannot fake-green that leg.
+    """
+    version = _env_var("SL_VERSION_SECONDARY")
+    if not version:
+        pytest.skip("SL_VERSION_SECONDARY resolved empty — set it in .env(.example)")
+    home_cli = Path.home() / f"starlake-{version}" / "starlake"
+    if home_cli.is_file():
+        return str(home_cli)
+    pytest.skip(
+        f"Secondary Starlake CLI {version} not found at {home_cli} — install with "
+        f"distrib/setup.sh --version={version} --target=$HOME/starlake-{version}"
+    )
 
 
 @pytest.fixture(scope="session")
@@ -297,3 +320,17 @@ def runtime_dags(runtime_env, tmp_path_factory):
         f"dag-generate failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
     return out, isolated, env
+
+
+@pytest.fixture(scope="module")
+def runtime_env_vars(runtime_dags):
+    """Apply the ``runtime_dags`` env to ``os.environ`` for the module.
+
+    Restores the previous environment on teardown. Promoted from the
+    snowflake integration/runtime modules so every orchestrator test
+    module can share it instead of keeping local copies.
+    """
+    _, _, env = runtime_dags
+    original = set_env(env)
+    yield env
+    restore_env(original)

--- a/tests/shared/lineage_utils.py
+++ b/tests/shared/lineage_utils.py
@@ -1,0 +1,135 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Orchestrator-agnostic lineage helpers and the canonical expected structure.
+
+Cross-orchestrator equivalence is asserted TRANSITIVELY: CI installs exactly
+one orchestrator per leg, so no test can compare two orchestrators in-process.
+Instead, every orchestrator leg normalizes its generated output and asserts it
+equals the canonical golden form below — all legs equal the same golden form
+implies all pairwise equal.
+
+NFR13: this module must stay orchestrator-agnostic — it operates on generated
+file text, parsed JSON, and ``AbstractPipeline``-level properties only.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+# Matches the transform template's embedded lineage:
+#   dependencies=StarlakeDependencies(dependencies="""[ ... ]""", ...)
+# Source: starlake-orchestration/src/main/resources/templates/dags/transform/
+# __scheduled_task_tpl.py.j2 (line 23)
+_DEPENDENCIES_RE = re.compile(
+    r'StarlakeDependencies\(dependencies="""(.*?)"""', re.DOTALL
+)
+
+
+def is_transform_dag(py_file: Path) -> bool:
+    """A generated transform DAG embeds a StarlakeDependencies JSON literal."""
+    return "StarlakeDependencies(dependencies=" in py_file.read_text(encoding="utf-8")
+
+
+def extract_embedded_lineage(py_file: Path) -> List[dict]:
+    """Extract and parse the CLI-computed lineage JSON from a generated transform DAG."""
+    source = py_file.read_text(encoding="utf-8")
+    match = _DEPENDENCIES_RE.search(source)
+    assert match is not None, f"No embedded lineage JSON found in {py_file.name}"
+    return json.loads(match.group(1))
+
+
+def normalize_lineage(tasks: List[dict]) -> Dict[str, object]:
+    """Canonical form of the embedded lineage: node->typ map + sorted edge list.
+
+    Edges are (upstream, downstream): a child feeds its parent entry.
+    Children can nest recursively — walk everything, sets dedup repeats.
+
+    Reads ONLY ``name``/``typ``/``children``. The 1.5.x CLI misplaces table
+    children's cron into their ``sink`` field, and future CLI versions may add
+    or fix fields — this minimalism IS the NFR7 tolerance mechanism. Never
+    extend it to ``sink``/``cron``/``writeStrategy``.
+    """
+    nodes: Dict[str, str] = {}
+    edges: Set[Tuple[str, str]] = set()
+
+    def walk(entry: dict) -> None:
+        data = entry.get("data", {})
+        assert "name" in data, f"Malformed lineage entry (no data.name): {entry!r}"
+        name = data["name"].lower()
+        nodes.setdefault(name, data.get("typ", "unknown"))
+        for child in entry.get("children", []):
+            child_data = child.get("data", {})
+            assert "name" in child_data, (
+                f"Malformed lineage child (no data.name): {child!r}"
+            )
+            edges.add((child_data["name"].lower(), name))
+            walk(child)
+
+    for entry in tasks:
+        walk(entry)
+    return {"nodes": nodes, "edges": sorted(edges)}
+
+
+def normalize_load_schedules(pipelines) -> Set[Tuple[str, str, str]]:
+    """Canonical load surface: {(cron, domain, table)} across all load pipelines.
+
+    Orchestrator-agnostic: only touches ``AbstractPipeline.schedule``
+    (StarlakeSchedule -> StarlakeDomain -> StarlakeTable).
+    """
+    triples: Set[Tuple[str, str, str]] = set()
+    for p in pipelines:
+        schedule = p.schedule
+        assert schedule is not None, f"{p.pipeline_id} has no schedule"
+        assert schedule.cron is not None, (
+            f"{p.pipeline_id} schedule {schedule.name} has no cron"
+        )
+        for domain in schedule.domains:
+            for table in domain.tables:
+                triples.add((schedule.cron, domain.name.lower(), table.name.lower()))
+    return triples
+
+
+# ---------------------------------------------------------------------------
+# Canonical expected structure for tests/sample-project (the golden form every
+# orchestrator leg must reproduce — transitive cross-orchestrator equivalence).
+# Confirmed against real dag-generate output (metadata/.build/dags artifacts):
+# names lowercase, typs task/table, crons after schedulePresets resolution.
+# ---------------------------------------------------------------------------
+
+EXPECTED_TRANSFORM_NODES = {
+    "kpi.order_summary": "task",
+    "kpi.top_customers": "task",
+    "starbake.orders": "table",
+    "starbake.customers": "table",
+    "starbake.products": "table",
+}
+
+EXPECTED_TRANSFORM_EDGES = [
+    ("kpi.order_summary", "kpi.top_customers"),
+    ("starbake.customers", "kpi.order_summary"),
+    ("starbake.orders", "kpi.order_summary"),
+    ("starbake.products", "kpi.order_summary"),
+]
+
+EXPECTED_LOAD_TRIPLES = {
+    ("0 * * * *", "starbake", "orders"),
+    ("0 0 * * *", "starbake", "customers"),
+    ("0 0 * * *", "starbake", "products"),
+}

--- a/tests/shared/test_lineage_cli_versions.py
+++ b/tests/shared/test_lineage_cli_versions.py
@@ -1,0 +1,126 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Mapping, Tuple
+
+import pytest
+
+from tests.shared.conftest import _env_var
+from tests.shared.lineage_utils import (
+    EXPECTED_TRANSFORM_EDGES,
+    EXPECTED_TRANSFORM_NODES,
+    extract_embedded_lineage,
+    is_transform_dag,
+    normalize_lineage,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+# String literals on purpose: importing StarlakeOrchestrator here would violate
+# NFR13 (tests/shared/ must stay orchestrator-agnostic — Story 1.1 convention).
+# dag-generate only renders templates bundled in the CLI assembly; no Python
+# orchestrator package is imported because this test never load_pipelines().
+_LOAD_DAG_REF = "airflow_load_shell"
+_TRANSFORM_DAG_REF = "airflow_transform_shell"
+
+
+def _dag_generate(
+    cli: str,
+    version: str,
+    starlake_env: Mapping[str, str],
+    sample_project_path: Path,
+    tmp_path: Path,
+    label: str,
+) -> Path:
+    """Copy the sample project and run dag-generate with the given CLI/version."""
+    project = tmp_path / f"project-{label}"
+    shutil.copytree(sample_project_path, project)
+    out = tmp_path / f"dags-{label}"
+    env = dict(starlake_env)
+    env["SL_ROOT"] = str(project)
+    # starlake.sh picks the jar via SL_JAR_NAME=...-$SL_VERSION-assembly.jar:
+    # each CLI install MUST run with its own version, never the inherited one.
+    env["SL_VERSION"] = version
+    env["LOAD_DAG_REF"] = _LOAD_DAG_REF
+    env["TRANSFORM_DAG_REF"] = _TRANSFORM_DAG_REF
+    try:
+        result = subprocess.run(
+            [cli, "dag-generate", "--outputDir", str(out)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"dag-generate ({label}, SL_VERSION={version}) timed out after 300s")
+    assert result.returncode == 0, (
+        f"dag-generate ({label}, SL_VERSION={version}) failed:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    return out
+
+
+def _normalized(out_dir: Path) -> Tuple[dict, list]:
+    files = sorted(out_dir.glob("*.py"))
+    assert files, f"No .py files generated in {out_dir}"
+    transform_files = [f for f in files if is_transform_dag(f)]
+    assert len(transform_files) == 1
+    norm = normalize_lineage(extract_embedded_lineage(transform_files[0]))
+    return norm, [f.name for f in files]
+
+
+class TestLineageCliVersionTolerance:
+    """NFR7: the lineage the framework consumes must be stable across CLI versions."""
+
+    def test_lineage_identical_across_cli_versions(
+        self,
+        starlake_cli,
+        starlake_cli_secondary,
+        starlake_env,
+        sample_project_path,
+        tmp_path,
+    ):
+        primary_out = _dag_generate(
+            starlake_cli, _env_var("SL_VERSION"),
+            starlake_env, sample_project_path, tmp_path, "primary",
+        )
+        secondary_out = _dag_generate(
+            starlake_cli_secondary, _env_var("SL_VERSION_SECONDARY"),
+            starlake_env, sample_project_path, tmp_path, "secondary",
+        )
+
+        primary_norm, primary_files = _normalized(primary_out)
+        secondary_norm, secondary_files = _normalized(secondary_out)
+
+        # Both CLI versions must produce the SAME canonical lineage...
+        # (technically implied by the two golden asserts below — kept because
+        # its failure message shows the actual divergence side by side)
+        assert primary_norm == secondary_norm, (
+            f"Lineage diverged between CLI versions:\n"
+            f"primary={primary_norm}\nsecondary={secondary_norm}"
+        )
+        # ...which is also the golden structure every orchestrator asserts.
+        assert primary_norm["nodes"] == EXPECTED_TRANSFORM_NODES
+        assert primary_norm["edges"] == EXPECTED_TRANSFORM_EDGES
+        # Same generated file set (names come from the DAG config, not the CLI).
+        assert primary_files == secondary_files

--- a/tests/snowflake/test_snowflake_integration.py
+++ b/tests/snowflake/test_snowflake_integration.py
@@ -22,7 +22,6 @@ import os
 import pytest
 
 from ai.starlake.orchestration import AbstractPipeline
-from tests.shared.conftest import set_env, restore_env
 
 
 # Mark all tests — they require Starlake CLI + Java runtime.
@@ -38,15 +37,6 @@ def generated_python_files(runtime_dags):
     files = sorted(dags_dir.glob("*.py"))
     assert len(files) > 0, f"No .py files in {dags_dir}"
     return files
-
-
-@pytest.fixture(scope="module")
-def runtime_env_vars(runtime_dags):
-    """Set runtime env vars for the module and restore on teardown."""
-    _, _, env = runtime_dags
-    original = set_env(env)
-    yield env
-    restore_env(original)
 
 
 # ------------------------------------------------------------------

--- a/tests/snowflake/test_snowflake_lineage.py
+++ b/tests/snowflake/test_snowflake_lineage.py
@@ -1,0 +1,126 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import pytest
+
+from tests.shared.lineage_utils import (
+    EXPECTED_LOAD_TRIPLES,
+    EXPECTED_TRANSFORM_EDGES,
+    EXPECTED_TRANSFORM_NODES,
+    extract_embedded_lineage,
+    is_transform_dag,
+    normalize_lineage,
+    normalize_load_schedules,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+
+@pytest.fixture(scope="module")
+def generated_python_files(runtime_dags):
+    """All generated .py DAG files (same fixture shape as the integration tests)."""
+    dags_dir, _, _ = runtime_dags
+    files = sorted(dags_dir.glob("*.py"))
+    assert len(files) > 0, f"No .py files in {dags_dir}"
+    return files
+
+
+@pytest.fixture(scope="module")
+def transform_pipelines(generated_python_files, runtime_env_vars):
+    """Load the (single) generated transform DAG through load_pipelines()."""
+    from ai.starlake.orchestration.__main__ import load_pipelines
+
+    transform_files = [f for f in generated_python_files if is_transform_dag(f)]
+    assert len(transform_files) == 1, (
+        f"Expected exactly one transform DAG, got: {[f.name for f in transform_files]}"
+    )
+    pipelines = load_pipelines(str(transform_files[0]))
+    assert pipelines, "No pipelines loaded from the transform DAG"
+    return pipelines
+
+
+class TestSnowflakeLineageConsumption:
+
+    # -- AC #1 / #3: CLI → template seam -------------------------------------
+
+    def test_embedded_lineage_matches_canonical_graph(self, generated_python_files):
+        """The CLI-computed lineage JSON embedded in the generated transform DAG
+        normalizes to the canonical graph shared by every orchestrator."""
+        transform_files = [f for f in generated_python_files if is_transform_dag(f)]
+        assert len(transform_files) == 1
+        normalized = normalize_lineage(extract_embedded_lineage(transform_files[0]))
+        assert normalized["nodes"] == EXPECTED_TRANSFORM_NODES
+        assert normalized["edges"] == EXPECTED_TRANSFORM_EDGES
+
+    # -- AC #1 / #3: template → framework seam -------------------------------
+
+    def test_transform_pipeline_dependency_structure(self, transform_pipelines):
+        """load_pipelines() yields the same logical task graph on every orchestrator."""
+        assert len(transform_pipelines) == 1
+        pipeline = transform_pipelines[0]
+
+        # CLI emits cron="None" (string); the framework must normalize it to None
+        assert pipeline.cron is None
+
+        # graphs: with load_dependencies=False only kpi.top_customers is a root
+        # graph, its filtered parents == {kpi.order_summary}
+        graphs = pipeline.graphs
+        assert graphs is not None
+        assert {g.id for g in graphs} == {"kpi.top_customers"}
+        (graph,) = tuple(graphs)
+        assert {p.id for p in graph.parents} == {"kpi.order_summary"}
+
+        # framework task graph — upstream_dependencies[A] lists A's DOWNSTREAMS
+        assert "kpi_top_customers_task" in pipeline.upstream_dependencies.get(
+            "kpi_order_summary_task", []
+        )
+        assert "kpi_order_summary_task" in pipeline.downstream_dependencies.get(
+            "kpi_top_customers_task", []
+        )
+        for task_id in ("kpi_order_summary_task", "kpi_top_customers_task"):
+            assert task_id in pipeline.tasks_names
+
+    # -- AC #2: sl_load() → sl_transform() lineage preservation --------------
+
+    def test_load_to_transform_lineage_preserved(self, generated_python_files):
+        """Every table node in the transform lineage is exactly a table the load
+        DAGs cover — the load → transform chain is closed."""
+        transform_files = [f for f in generated_python_files if is_transform_dag(f)]
+        lineage = normalize_lineage(extract_embedded_lineage(transform_files[0]))
+        table_nodes = {n for n, typ in lineage["nodes"].items() if typ == "table"}
+        load_tables = {f"{d}.{t}" for (_, d, t) in EXPECTED_LOAD_TRIPLES}
+        assert table_nodes == load_tables
+
+    # -- AC #1 / #3: load-side logical surface --------------------------------
+
+    def test_load_pipelines_cover_canonical_tables(
+        self, generated_python_files, runtime_env_vars
+    ):
+        """All load pipelines together cover exactly the canonical
+        {(cron, domain, table)} set — file layout may differ per orchestrator
+        (Snowflake generates one DAG per table), the logical surface may not."""
+        from ai.starlake.orchestration.__main__ import load_pipelines
+
+        load_files = [f for f in generated_python_files if not is_transform_dag(f)]
+        assert load_files, "No load DAGs generated"
+        pipelines = []
+        for f in load_files:
+            pipelines.extend(load_pipelines(str(f)) or [])
+        assert normalize_load_schedules(pipelines) == EXPECTED_LOAD_TRIPLES

--- a/tests/snowflake/test_snowflake_runtime.py
+++ b/tests/snowflake/test_snowflake_runtime.py
@@ -22,7 +22,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ai.starlake.orchestration import AbstractPipeline
-from tests.shared.conftest import set_env, restore_env
 
 
 # Mark all tests — they require Starlake CLI + Java runtime.
@@ -47,15 +46,6 @@ def runtime_mock_session():
     session.sql.return_value.collect.return_value = []
     session.call.return_value = None
     return session
-
-
-@pytest.fixture(scope="module")
-def runtime_env_vars(runtime_dags):
-    """Set runtime env vars for the module and restore on teardown."""
-    _, _, env = runtime_dags
-    original = set_env(env)
-    yield env
-    restore_env(original)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary

Tests-only change proving the framework consumes the Starlake lineage graph identically across all orchestrators, plus Starlake CLI version tolerance (NFR7).

- **Golden-canonical transitive equivalence**: `tests/shared/lineage_utils.py` holds orchestrator-agnostic normalization helpers and the canonical expected structure for the sample project (transform nodes/edges + `{(cron, domain, table)}` load triples). Each CI leg asserts `normalize(its output) == golden`, so all orchestrators are pairwise equivalent without ever co-installing two of them.
- **Two-seam validation per orchestrator** (`tests/{airflow,dagster,snowflake}/test_*_lineage.py`, byte-identical apart from the class name): the CLI-computed lineage JSON embedded in generated transform DAGs, and the logical task graph from `load_pipelines()` (`graphs`, `upstream_dependencies`, `downstream_dependencies`, `tasks_names`, `schedule`). Load-side equivalence is asserted on the logical surface (Snowflake generates one DAG file per table by design).
- **NFR7 dual-CLI test**: `tests/shared/test_lineage_cli_versions.py` runs `dag-generate` with the pinned CLI (1.5.11) and a secondary install (`SL_VERSION_SECONDARY=1.5.15`, separate target `~/starlake-1.5.15`), asserting identical normalized lineage. Skips cleanly when the secondary CLI is absent; CI installs, caches and sanity-checks it on the orchestration leg only (`SL_VERSION` explicitly overridden — the launcher selects the jar by that variable).
- **Fixture dedup**: `runtime_env_vars` promoted to `tests/shared/conftest.py`; both duplicated snowflake copies removed.

## Test results (local, fresh CI-equivalent venvs, non-editable installs)

| Leg | Result |
|-----|--------|
| orchestration (tests/orchestration + tests/shared) | 114 passed; NFR7 test green against a real 1.5.11/1.5.15 pair |
| airflow 2.10.5 | 128 passed |
| airflow 3.3.0 | 119 passed, 9 expected skips |
| dagster 1.9.13 | 89 passed |
| snowflake | 65 passed, 7 pre-existing xfails |

Empirical NFR7 note: CLI 1.5.11 and 1.5.15 produce identical normalized lineage and identical generated file sets for the sample project.

Related: #65 (latent `StarlakeDependencies.get_dependency()` bug documented during this work — not fixed here).

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)