### PR TITLE
Story 3.3 — Cross-orchestrator sl_* action behavior consistency

### DIFF
--- a/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_job.py
@@ -618,7 +618,11 @@ class StarlakeAirflowJob(IStarlakeJob[BaseOperator, Dataset], StarlakeAirflowOpt
         Returns:
             Optional[BaseOperator]: The Airflow task or None.
         """
-        pre_load_strategy = self.pre_load_strategy if not pre_load_strategy else pre_load_strategy
+        pre_load_strategy = self.__class__.sl_resolve_pre_load_strategy(
+            pre_load_strategy,
+            default=self.pre_load_strategy,
+            action="sl_pre_load(pre_load_strategy=...)",
+        )
         kwargs.update({'pool': kwargs.get('pool', self.pool)})
         kwargs.update({'do_xcom_push': True})
         kwargs.update({'doc': kwargs.get('doc', f'Pre-load for tables {",".join(list(tables or []))} within {domain} using {pre_load_strategy.value} strategy.')})

--- a/starlake-dagster/src/main/python/ai/starlake/dagster/starlake_dagster_job.py
+++ b/starlake-dagster/src/main/python/ai/starlake/dagster/starlake_dagster_job.py
@@ -59,9 +59,11 @@ class StarlakeDagsterJob(IStarlakeJob[NodeDefinition, AssetKey], StarlakeOptions
         """
 
         if isinstance(pre_load_strategy, str):
-            pre_load_strategy = \
-                StarlakePreLoadStrategy(pre_load_strategy) if StarlakePreLoadStrategy.is_valid(pre_load_strategy) \
-                    else self.pre_load_strategy
+            pre_load_strategy = self.__class__.sl_resolve_pre_load_strategy(
+                pre_load_strategy,
+                default=self.pre_load_strategy,
+                action="sl_pre_load(pre_load_strategy=...)",
+            )
 
         pre_load_strategy = self.pre_load_strategy if not pre_load_strategy else pre_load_strategy
 

--- a/starlake-orchestration/src/main/python/ai/starlake/job/starlake_job.py
+++ b/starlake-orchestration/src/main/python/ai/starlake/job/starlake_job.py
@@ -114,9 +114,11 @@ class IStarlakeJob(Generic[T, E], StarlakeOptions, AbstractEvent[E]):
         ) if not pre_load_strategy else pre_load_strategy
 
         if isinstance(pre_load_strategy, str):
-            pre_load_strategy = \
-                StarlakePreLoadStrategy(pre_load_strategy) if StarlakePreLoadStrategy.is_valid(pre_load_strategy) \
-                    else StarlakePreLoadStrategy.NONE
+            pre_load_strategy = self.__class__.sl_resolve_pre_load_strategy(
+                pre_load_strategy,
+                default=StarlakePreLoadStrategy.NONE,
+                action="options['pre_load_strategy']",
+            )
 
         self.pre_load_strategy: StarlakePreLoadStrategy = pre_load_strategy
 
@@ -300,6 +302,41 @@ class IStarlakeJob(Generic[T, E], StarlakeOptions, AbstractEvent[E]):
         """
         return None
 
+    @classmethod
+    def sl_resolve_pre_load_strategy(
+        cls,
+        value: Union[StarlakePreLoadStrategy, str, None],
+        default: Optional[StarlakePreLoadStrategy] = None,
+        action: str = "pre_load_strategy",
+    ) -> Optional[StarlakePreLoadStrategy]:
+        """Resolve a pre-load strategy value, failing fast on invalid strings.
+
+        Args:
+            value: The raw value (enum, string, or None).
+            default: Returned when value is None or empty (backward compatible).
+            action: The action or configuration key for the error message (NFR11).
+
+        Returns:
+            Optional[StarlakePreLoadStrategy]: The resolved strategy.
+
+        Raises:
+            ValueError: If value is a non-empty string that is not a valid
+                strategy. The message includes the orchestrator name, the
+                action/configuration key, the invalid value and the valid values.
+        """
+        if not value:
+            return default
+        if isinstance(value, StarlakePreLoadStrategy):
+            return value
+        if StarlakePreLoadStrategy.is_valid(value):
+            return StarlakePreLoadStrategy(value)
+        orchestrator = cls.sl_orchestrator() or "unknown"
+        valid = ", ".join(s.value for s in StarlakePreLoadStrategy)
+        raise ValueError(
+            f"[{orchestrator}] {action}: invalid pre-load strategy '{value}' "
+            f"— valid values: {valid}"
+        )
+
     @property
     def events(self) -> List[E]:
         """Returns the events.
@@ -419,9 +456,11 @@ class IStarlakeJob(Generic[T, E], StarlakeOptions, AbstractEvent[E]):
             Optional[T]: The scheduler task or None.
         """
         if isinstance(pre_load_strategy, str):
-            pre_load_strategy = \
-                StarlakePreLoadStrategy(pre_load_strategy) if StarlakePreLoadStrategy.is_valid(pre_load_strategy) \
-                    else self.pre_load_strategy
+            pre_load_strategy = self.__class__.sl_resolve_pre_load_strategy(
+                pre_load_strategy,
+                default=self.pre_load_strategy,
+                action="sl_pre_load(pre_load_strategy=...)",
+            )
 
         pre_load_strategy = self.pre_load_strategy if not pre_load_strategy else pre_load_strategy
 

--- a/starlake-snowflake/src/main/python/ai/starlake/snowflake/starlake_snowflake_job.py
+++ b/starlake-snowflake/src/main/python/ai/starlake/snowflake/starlake_snowflake_job.py
@@ -664,7 +664,9 @@ class StarlakeSnowflakeJob(IStarlakeJob[DAGTask, StarlakeDataset], StarlakeOptio
                     raise ValueError("context is required")
             else:
                 # only load and transform commands are implemented
-                raise NotImplementedError(f"{task_type} is not implemented")
+                raise NotImplementedError(
+                    f"[{self.__class__.sl_orchestrator()}] sl_job: task type '{task_type}' is not implemented"
+                )
         else:
             # sink is required
             raise ValueError("sink is required")

--- a/tests/airflow/test_airflow_runtime.py
+++ b/tests/airflow/test_airflow_runtime.py
@@ -44,6 +44,13 @@ from datetime import datetime, timezone
 import pytest
 
 from tests.shared.conftest import get_duckdb, restore_env, set_env
+from tests.shared.expected_results import (
+    EXPECTED_KPI_SNAPSHOTS,
+    EXPECTED_ROW_COUNTS,
+    EXPECTED_TABLE_SNAPSHOTS,
+    TOP_CUSTOMERS_MAX_ROWS,
+    table_snapshot,
+)
 
 try:
     import airflow
@@ -270,20 +277,25 @@ class TestAirflowRuntimeLoad:
         _, isolated, _ = executed_load_dags
         conn = get_duckdb(isolated)
         try:
-            customers = conn.execute(
-                "SELECT count(*) FROM starbake.customers"
-            ).fetchone()[0]
-            assert customers == 7, f"Expected 7 customers, got {customers}"
+            for table, expected_count in EXPECTED_ROW_COUNTS.items():
+                count = conn.execute(
+                    f"SELECT count(*) FROM {table}"
+                ).fetchone()[0]
+                assert count == expected_count, (
+                    f"Expected {expected_count} rows in {table}, got {count}"
+                )
+        finally:
+            conn.close()
 
-            orders = conn.execute(
-                "SELECT count(*) FROM starbake.orders"
-            ).fetchone()[0]
-            assert orders == 10, f"Expected 10 orders, got {orders}"
-
-            products = conn.execute(
-                "SELECT count(*) FROM starbake.products"
-            ).fetchone()[0]
-            assert products == 5, f"Expected 5 products, got {products}"
+    def test_duckdb_state_matches_canonical_snapshots(self, executed_load_dags):
+        """NFR1: the loaded data equals the canonical cross-orchestrator snapshot."""
+        _, isolated, _ = executed_load_dags
+        conn = get_duckdb(isolated)
+        try:
+            for table, expected_rows in EXPECTED_TABLE_SNAPSHOTS.items():
+                assert table_snapshot(conn, table) == expected_rows, (
+                    f"{table}: DuckDB state diverges from the canonical snapshot"
+                )
         finally:
             conn.close()
 
@@ -337,9 +349,24 @@ class TestAirflowRuntimeTransform:
                 "SELECT count(*) FROM kpi.top_customers"
             ).fetchone()[0]
             assert top_customers > 0, "kpi.top_customers is empty"
-            assert top_customers <= 5, (
-                f"top_customers has {top_customers} rows, expected <= 5"
+            assert top_customers <= TOP_CUSTOMERS_MAX_ROWS, (
+                f"top_customers has {top_customers} rows, "
+                f"expected <= {TOP_CUSTOMERS_MAX_ROWS}"
             )
+        finally:
+            conn.close()
+
+    def test_transform_results_match_canonical_snapshots(
+        self, executed_transform_dags
+    ):
+        """NFR1: transform outputs equal the canonical cross-orchestrator snapshot."""
+        _, isolated, _ = executed_transform_dags
+        conn = get_duckdb(isolated)
+        try:
+            for table, expected_rows in EXPECTED_KPI_SNAPSHOTS.items():
+                assert table_snapshot(conn, table) == expected_rows, (
+                    f"{table}: DuckDB state diverges from the canonical snapshot"
+                )
         finally:
             conn.close()
 

--- a/tests/airflow/test_airflow_sl_action_consistency.py
+++ b/tests/airflow/test_airflow_sl_action_consistency.py
@@ -1,0 +1,24 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from tests.airflow.airflow_test_mixin import AirflowTestMixin
+from tests.shared.base_test_sl_action_consistency import BaseTestSlActionConsistency
+
+
+class TestAirflowSlActionConsistency(AirflowTestMixin, BaseTestSlActionConsistency):
+    """Airflow canonical sl_* contract — runs unchanged on Airflow 2 and 3."""

--- a/tests/dagster/test_dagster_runtime.py
+++ b/tests/dagster/test_dagster_runtime.py
@@ -37,6 +37,13 @@ import pytest
 from dagster import AssetKey, DagsterInstance
 
 from tests.shared.conftest import get_duckdb, restore_env, set_env
+from tests.shared.expected_results import (
+    EXPECTED_KPI_SNAPSHOTS,
+    EXPECTED_ROW_COUNTS,
+    EXPECTED_TABLE_SNAPSHOTS,
+    TOP_CUSTOMERS_MAX_ROWS,
+    table_snapshot,
+)
 
 pytestmark = [
     pytest.mark.integration,
@@ -154,20 +161,25 @@ class TestDagsterRuntimeLoad:
         _, isolated, _ = executed_load_jobs
         conn = get_duckdb(isolated)
         try:
-            customers = conn.execute(
-                "SELECT count(*) FROM starbake.customers"
-            ).fetchone()[0]
-            assert customers == 7, f"Expected 7 customers, got {customers}"
+            for table, expected_count in EXPECTED_ROW_COUNTS.items():
+                count = conn.execute(
+                    f"SELECT count(*) FROM {table}"
+                ).fetchone()[0]
+                assert count == expected_count, (
+                    f"Expected {expected_count} rows in {table}, got {count}"
+                )
+        finally:
+            conn.close()
 
-            orders = conn.execute(
-                "SELECT count(*) FROM starbake.orders"
-            ).fetchone()[0]
-            assert orders == 10, f"Expected 10 orders, got {orders}"
-
-            products = conn.execute(
-                "SELECT count(*) FROM starbake.products"
-            ).fetchone()[0]
-            assert products == 5, f"Expected 5 products, got {products}"
+    def test_duckdb_state_matches_canonical_snapshots(self, executed_load_jobs):
+        """NFR1: the loaded data equals the canonical cross-orchestrator snapshot."""
+        _, isolated, _ = executed_load_jobs
+        conn = get_duckdb(isolated)
+        try:
+            for table, expected_rows in EXPECTED_TABLE_SNAPSHOTS.items():
+                assert table_snapshot(conn, table) == expected_rows, (
+                    f"{table}: DuckDB state diverges from the canonical snapshot"
+                )
         finally:
             conn.close()
 
@@ -220,9 +232,24 @@ class TestDagsterRuntimeTransform:
                 "SELECT count(*) FROM kpi.top_customers"
             ).fetchone()[0]
             assert top_customers > 0, "kpi.top_customers is empty"
-            assert top_customers <= 5, (
-                f"top_customers has {top_customers} rows, expected <= 5"
+            assert top_customers <= TOP_CUSTOMERS_MAX_ROWS, (
+                f"top_customers has {top_customers} rows, "
+                f"expected <= {TOP_CUSTOMERS_MAX_ROWS}"
             )
+        finally:
+            conn.close()
+
+    def test_transform_results_match_canonical_snapshots(
+        self, executed_transform_jobs
+    ):
+        """NFR1: transform outputs equal the canonical cross-orchestrator snapshot."""
+        _, isolated, _ = executed_transform_jobs
+        conn = get_duckdb(isolated)
+        try:
+            for table, expected_rows in EXPECTED_KPI_SNAPSHOTS.items():
+                assert table_snapshot(conn, table) == expected_rows, (
+                    f"{table}: DuckDB state diverges from the canonical snapshot"
+                )
         finally:
             conn.close()
 

--- a/tests/dagster/test_dagster_sl_action_consistency.py
+++ b/tests/dagster/test_dagster_sl_action_consistency.py
@@ -1,0 +1,24 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from tests.dagster.dagster_test_mixin import DagsterTestMixin
+from tests.shared.base_test_sl_action_consistency import BaseTestSlActionConsistency
+
+
+class TestDagsterSlActionConsistency(DagsterTestMixin, BaseTestSlActionConsistency):
+    """Dagster canonical sl_* contract."""

--- a/tests/orchestration/test_pre_load_strategy_validation.py
+++ b/tests/orchestration/test_pre_load_strategy_validation.py
@@ -1,0 +1,109 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import pytest
+
+from ai.starlake.job.starlake_pre_load_strategy import StarlakePreLoadStrategy
+
+from tests.orchestration.conftest import StubJob, _STUB_MODULE_NAME
+
+
+class TestPreLoadStrategyValidation:
+    """Strict pre-load strategy resolution (NFR11) — core contract."""
+
+    def test_invalid_string_in_options_raises(self):
+        with pytest.raises(ValueError) as exc_info:
+            StubJob(
+                filename="test.py",
+                module_name=_STUB_MODULE_NAME,
+                options={"pre_load_strategy": "imprted"},
+            )
+        message = str(exc_info.value)
+        assert "STUB" in message
+        assert "imprted" in message
+        assert "pre_load_strategy" in message
+        for valid in ("imported", "ack", "pending", "none"):
+            assert valid in message
+
+    def test_invalid_string_argument_raises(self, stub_job):
+        with pytest.raises(ValueError, match="not-a-strategy"):
+            stub_job.sl_pre_load(domain="starbake", pre_load_strategy="not-a-strategy")
+
+    def test_invalid_string_argument_message_contract(self, stub_job):
+        with pytest.raises(ValueError) as exc_info:
+            stub_job.sl_pre_load(domain="starbake", pre_load_strategy="imprted")
+        message = str(exc_info.value)
+        assert "STUB" in message
+        assert "imprted" in message
+        assert "sl_pre_load" in message
+        for valid in ("imported", "ack", "pending", "none"):
+            assert valid in message
+
+    @pytest.mark.parametrize("value,expected", [
+        ("imported", StarlakePreLoadStrategy.IMPORTED),
+        ("ack", StarlakePreLoadStrategy.ACK),
+        ("pending", StarlakePreLoadStrategy.PENDING),
+        ("none", StarlakePreLoadStrategy.NONE),
+    ])
+    def test_valid_strings_still_resolve(self, value, expected):
+        job = StubJob(
+            filename="test.py",
+            module_name=_STUB_MODULE_NAME,
+            options={"pre_load_strategy": value},
+        )
+        assert job.pre_load_strategy == expected
+
+    def test_valid_string_argument_still_resolves(self, stub_job):
+        task = stub_job.sl_pre_load(domain="starbake", pre_load_strategy="imported")
+        assert task is not None
+        assert task["task_id"] == "check_starbake_incoming_files"
+        args = task["arguments"]
+        assert args[0] == "preload"
+        idx = args.index("--strategy")
+        assert args[idx + 1] == "imported"
+
+    def test_none_and_empty_fall_back_to_default(self):
+        job = StubJob(filename="test.py", module_name=_STUB_MODULE_NAME, options={})
+        assert job.pre_load_strategy == StarlakePreLoadStrategy.NONE
+        # empty string behaves like "not configured" (backward compatible)
+        job2 = StubJob(
+            filename="test.py",
+            module_name=_STUB_MODULE_NAME,
+            options={"pre_load_strategy": ""},
+        )
+        assert job2.pre_load_strategy == StarlakePreLoadStrategy.NONE
+
+    def test_helper_enum_passthrough_and_default(self):
+        assert (
+            StubJob.sl_resolve_pre_load_strategy(StarlakePreLoadStrategy.ACK)
+            == StarlakePreLoadStrategy.ACK
+        )
+        assert (
+            StubJob.sl_resolve_pre_load_strategy(
+                None, default=StarlakePreLoadStrategy.PENDING
+            )
+            == StarlakePreLoadStrategy.PENDING
+        )
+        assert StubJob.sl_resolve_pre_load_strategy("") is None
+
+    def test_helper_unknown_orchestrator_falls_back_to_unknown(self):
+        from ai.starlake.job.starlake_job import IStarlakeJob
+
+        with pytest.raises(ValueError) as exc_info:
+            IStarlakeJob.sl_resolve_pre_load_strategy("bogus")
+        assert "[unknown]" in str(exc_info.value)

--- a/tests/shared/base_test_sl_action_consistency.py
+++ b/tests/shared/base_test_sl_action_consistency.py
@@ -1,0 +1,132 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+
+from ai.starlake.orchestration import AbstractPipeline, StarlakeSchedule
+
+from tests.shared.base_test_orchestration import BaseTestOrchestration
+from tests.shared.expected_results import CLI_CONTRACT, EXPECTED_TASK_IDS
+
+
+class BaseTestSlActionConsistency(BaseTestOrchestration):
+    """Cross-orchestrator sl_* action contract (NFR1 structural layer + NFR11).
+
+    Every concrete orchestrator subclass runs the SAME scenario against the
+    SAME canonical constants — equivalence across orchestrators is transitive
+    through tests/shared/expected_results.py.
+    """
+
+    def _make_pipeline(self, options: Optional[dict] = None) -> AbstractPipeline:
+        schedule = StarlakeSchedule(name=None, cron=None, domains=[])
+        return self.create_test_pipeline(schedule=schedule, options=options)
+
+    def _assert_contract(self, args, contract_key):
+        contract = CLI_CONTRACT[contract_key]
+        assert args, f"no CLI arguments extracted for {contract_key}"
+        assert args[0] == contract["verb"], (
+            f"{contract_key}: expected verb '{contract['verb']}', got '{args[0]}' in {args}"
+        )
+        for flag, value in contract["flags"].items():
+            assert self.get_arg_value(args, flag) == value
+
+    # --- canonical action contracts (through the pipeline, never raw) ---
+
+    def test_canonical_load_contract(self):
+        pipeline = self._make_pipeline()
+        with pipeline:
+            t = pipeline.sl_load(
+                task_id=EXPECTED_TASK_IDS["load_customers"],
+                domain="starbake",
+                table="customers",
+            )
+        assert t is not None
+        assert t.task_id == EXPECTED_TASK_IDS["load_customers"]
+        self._assert_contract(self.get_task_arguments(t.task), "load")
+
+    def test_canonical_transform_contract(self):
+        pipeline = self._make_pipeline()
+        with pipeline:
+            t = pipeline.sl_transform(
+                task_id=EXPECTED_TASK_IDS["transform_order_summary"],
+                transform_name="kpi.order_summary",
+            )
+        assert t is not None
+        assert t.task_id == EXPECTED_TASK_IDS["transform_order_summary"]
+        self._assert_contract(self.get_task_arguments(t.task), "transform")
+
+    def test_canonical_import_contract(self):
+        pipeline = self._make_pipeline()
+        with pipeline:
+            t = pipeline.sl_import(
+                task_id=EXPECTED_TASK_IDS["import"],
+                domain="starbake",
+            )
+        assert t is not None
+        assert t.task_id == EXPECTED_TASK_IDS["import"]
+        self._assert_contract(self.get_task_arguments(t.task), "import")
+
+    def test_canonical_pre_load_chain(self):
+        """IMPORTED chain: sl_pre_load >> sl_import >> sl_load (never skip import)."""
+        pipeline = self._make_pipeline(options={"pre_load_strategy": "imported"})
+        with pipeline:
+            t_pre = pipeline.sl_pre_load(domain="starbake", tables=set())
+            t_import = pipeline.sl_import(
+                task_id=EXPECTED_TASK_IDS["import"], domain="starbake"
+            )
+            t_load = pipeline.sl_load(
+                task_id=EXPECTED_TASK_IDS["load_customers"],
+                domain="starbake",
+                table="customers",
+            )
+            assert t_pre is not None
+            assert t_pre.task_id == EXPECTED_TASK_IDS["pre_load_imported"]
+            self._assert_contract(self.get_task_arguments(t_pre.task), "pre_load")
+            t_pre >> t_import >> t_load
+            assert EXPECTED_TASK_IDS["import"] in pipeline.upstream_dependencies.get(
+                EXPECTED_TASK_IDS["pre_load_imported"], []
+            )
+            assert EXPECTED_TASK_IDS["load_customers"] in pipeline.upstream_dependencies.get(
+                EXPECTED_TASK_IDS["import"], []
+            )
+
+    # --- NFR11: orchestrator-named errors on invalid strategy ---
+
+    def test_invalid_pre_load_strategy_argument_raises_with_orchestrator_name(self):
+        """The job-API error contract: AbstractPipeline.sl_pre_load deliberately
+        exposes no strategy parameter, so the argument path is exercised on the
+        job (the only public surface that takes a strategy argument)."""
+        orchestration = self.create_orchestration()
+        job = orchestration.job
+        orchestrator_name = str(job.sl_orchestrator())
+        with pytest.raises(ValueError) as exc_info:
+            job.sl_pre_load(domain="starbake", pre_load_strategy="imprted")  # typo on purpose
+        message = str(exc_info.value)
+        assert orchestrator_name in message
+        assert "imprted" in message
+        for valid in ("imported", "ack", "pending", "none"):
+            assert valid in message
+
+    def test_invalid_pre_load_strategy_option_raises_with_orchestrator_name(self):
+        with pytest.raises(ValueError) as exc_info:
+            self.create_orchestration(options={"pre_load_strategy": "bogus"})
+        message = str(exc_info.value)
+        assert "bogus" in message
+        assert "pre_load_strategy" in message

--- a/tests/shared/expected_results.py
+++ b/tests/shared/expected_results.py
@@ -1,0 +1,176 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Canonical cross-orchestrator scenario contract (NFR1).
+
+Single source of truth for what the sample-project scenario must produce,
+regardless of orchestrator. Every orchestrator leg asserts against THESE
+constants; equivalence between orchestrators is transitive through them.
+NFR13: no orchestrator imports allowed in this module.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+# --- structural contract -------------------------------------------------
+
+EXPECTED_TASK_IDS = {
+    "load_customers": "load_starbake_customers",
+    "load_orders": "load_starbake_orders",
+    "load_products": "load_starbake_products",
+    "pre_load_imported": "check_starbake_incoming_files",
+    "import": "import_starbake",
+    # NOTE: Dagster op names forbid dots — the shared convention (established
+    # in tests/shared/base_test_sl_transform.py) is an underscored task_id
+    # with the dotted transform_name passed separately.
+    "transform_order_summary": "kpi_order_summary",
+    "transform_top_customers": "kpi_top_customers",
+}
+
+# action verb (args[0]) + flag/value pairs that MUST be present, per action.
+CLI_CONTRACT = {
+    "load": {"verb": "load", "flags": {"--domains": "starbake", "--tables": "customers"}},
+    "transform": {"verb": "transform", "flags": {"--name": "kpi.order_summary"}},
+    "import": {"verb": "stage", "flags": {"--domains": "starbake"}},
+    "pre_load": {"verb": "preload", "flags": {"--domain": "starbake", "--strategy": "imported"}},
+}
+
+# --- runtime data contract ----------------------------------------------
+
+EXPECTED_ROW_COUNTS = {
+    "starbake.customers": 7,
+    "starbake.orders": 10,
+    "starbake.products": 5,
+}
+
+EXPECTED_KPI_ROW_COUNTS = {
+    "kpi.order_summary": 7,
+    "kpi.top_customers": 5,
+}
+
+TOP_CUSTOMERS_MAX_ROWS = 5
+
+# Business columns only (Starlake may add audit columns depending on config);
+# ORDER BY the natural key so snapshots are deterministic.
+SNAPSHOT_QUERIES = {
+    "starbake.customers": (
+        "SELECT id, first_name, last_name, email, CAST(join_date AS VARCHAR) "
+        "FROM starbake.customers ORDER BY id"
+    ),
+    "starbake.orders": (
+        "SELECT order_id, customer_id, product_id, quantity, CAST(order_date AS VARCHAR) "
+        "FROM starbake.orders ORDER BY order_id"
+    ),
+    "starbake.products": (
+        "SELECT product_id, name, category, ROUND(price, 2), ROUND(cost, 2) "
+        "FROM starbake.products ORDER BY product_id"
+    ),
+    "kpi.order_summary": (
+        "SELECT customer_id, customer_name, email, total_orders, total_items, "
+        "ROUND(total_spent, 2), CAST(first_order_date AS VARCHAR), "
+        "CAST(last_order_date AS VARCHAR) "
+        "FROM kpi.order_summary ORDER BY customer_id"
+    ),
+    "kpi.top_customers": (
+        "SELECT customer_id, customer_name, email, total_orders, total_items, "
+        "ROUND(total_spent, 2) "
+        "FROM kpi.top_customers ORDER BY customer_id"
+    ),
+}
+
+
+def table_snapshot(conn, table: str) -> List[Tuple]:
+    """Deterministic, normalized snapshot of *table* via its SNAPSHOT_QUERY."""
+    return [tuple(row) for row in conn.execute(SNAPSHOT_QUERIES[table]).fetchall()]
+
+
+# Literal expected rows — generated once from a reference run of the sample
+# project (Starlake CLI load + transforms against DuckDB, dumped through
+# SNAPSHOT_QUERIES), reviewed against the sample-project CSVs and committed.
+# Both the Airflow and the Dagster runtime suites must reproduce these EXACT
+# rows.
+EXPECTED_TABLE_SNAPSHOTS = {
+    "starbake.customers": [
+        # (id, first_name, last_name, email, join_date)
+        (1, "John", "Doe", "john.doe@email.com", "2023-01-15"),
+        (2, "Jane", "Smith", "jane.smith@email.com", "2023-02-03"),
+        (3, "Michael", "Johnson", "michael.johnson@email.com", "2023-02-28"),
+        (4, "Emily", "Brown", "emily.brown@email.com", "2023-03-10"),
+        (5, "David", "Wilson", "david.wilson@email.com", "2023-04-05"),
+        (6, "Sarah", "Taylor", "sarah.taylor@email.com", "2023-04-22"),
+        (7, "Robert", "Anderson", "robert.anderson@email.com", "2023-05-18"),
+    ],
+    "starbake.orders": [
+        # (order_id, customer_id, product_id, quantity, order_date)
+        (1, 1, 1, 2, "2023-01-20"),
+        (2, 1, 3, 1, "2023-01-25"),
+        (3, 2, 2, 3, "2023-02-10"),
+        (4, 3, 1, 1, "2023-03-15"),
+        (5, 3, 4, 2, "2023-03-15"),
+        (6, 4, 2, 2, "2023-03-25"),
+        (7, 5, 3, 1, "2023-04-08"),
+        (8, 5, 5, 3, "2023-04-08"),
+        (9, 6, 4, 2, "2023-04-30"),
+        (10, 7, 5, 1, "2023-05-20"),
+    ],
+    "starbake.products": [
+        # (product_id, name, category, price, cost)
+        (1, "Baguette", "bread", 14.33, 8.12),
+        (2, "Chocolate Croissant", "pastry", 3.99, 1.75),
+        (3, "Sourdough Loaf", "bread", 6.5, 3.25),
+        (4, "Blueberry Muffin", "pastry", 2.75, 1.2),
+        (5, "Cinnamon Roll", "pastry", 3.5, 1.8),
+    ],
+}
+
+EXPECTED_KPI_SNAPSHOTS = {
+    "kpi.order_summary": [
+        # (customer_id, customer_name, email, total_orders, total_items,
+        #  total_spent, first_order_date, last_order_date)
+        (1, "John Doe", "john.doe@email.com", 2, 3, 35.16, "2023-01-20", "2023-01-25"),
+        (2, "Jane Smith", "jane.smith@email.com", 1, 3, 11.97, "2023-02-10", "2023-02-10"),
+        (3, "Michael Johnson", "michael.johnson@email.com", 2, 3, 19.83, "2023-03-15", "2023-03-15"),
+        (4, "Emily Brown", "emily.brown@email.com", 1, 2, 7.98, "2023-03-25", "2023-03-25"),
+        (5, "David Wilson", "david.wilson@email.com", 2, 4, 17.0, "2023-04-08", "2023-04-08"),
+        (6, "Sarah Taylor", "sarah.taylor@email.com", 1, 2, 5.5, "2023-04-30", "2023-04-30"),
+        (7, "Robert Anderson", "robert.anderson@email.com", 1, 1, 3.5, "2023-05-20", "2023-05-20"),
+    ],
+    "kpi.top_customers": [
+        # Top 5 by total_spent (no tie at the cut boundary — deterministic):
+        # 35.16 > 19.83 > 17.0 > 11.97 > 7.98 | excluded: 5.5, 3.5
+        (1, "John Doe", "john.doe@email.com", 2, 3, 35.16),
+        (2, "Jane Smith", "jane.smith@email.com", 1, 3, 11.97),
+        (3, "Michael Johnson", "michael.johnson@email.com", 2, 3, 19.83),
+        (4, "Emily Brown", "emily.brown@email.com", 1, 2, 7.98),
+        (5, "David Wilson", "david.wilson@email.com", 2, 4, 17.0),
+    ],
+}
+
+# Guard against drift between counts and literals (fails at import time).
+for _t, _rows in EXPECTED_TABLE_SNAPSHOTS.items():
+    assert len(_rows) == EXPECTED_ROW_COUNTS[_t], (
+        f"expected_results drift: {_t} snapshot has {len(_rows)} rows, "
+        f"EXPECTED_ROW_COUNTS says {EXPECTED_ROW_COUNTS[_t]}"
+    )
+for _t, _rows in EXPECTED_KPI_SNAPSHOTS.items():
+    assert len(_rows) == EXPECTED_KPI_ROW_COUNTS[_t], (
+        f"expected_results drift: {_t} snapshot has {len(_rows)} rows, "
+        f"EXPECTED_KPI_ROW_COUNTS says {EXPECTED_KPI_ROW_COUNTS[_t]}"
+    )
+assert len(EXPECTED_KPI_SNAPSHOTS["kpi.top_customers"]) <= TOP_CUSTOMERS_MAX_ROWS
+
+del _t, _rows  # keep the module namespace clean (loop guard variables)

--- a/tests/snowflake/test_snowflake_sl_action_consistency.py
+++ b/tests/snowflake/test_snowflake_sl_action_consistency.py
@@ -1,0 +1,50 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import pytest
+
+from tests.snowflake.snowflake_test_mixin import SnowflakeTestMixin
+from tests.shared.base_test_sl_action_consistency import BaseTestSlActionConsistency
+
+
+class TestSnowflakeSlActionConsistency(SnowflakeTestMixin, BaseTestSlActionConsistency):
+    """Snowflake canonical sl_* contract.
+
+    Runtime data equivalence (AC #3) deliberately EXCLUDES Snowflake:
+    the SQL executor runs inside Snowflake and the test suite mocks the
+    SDK — there is no local DuckDB state to compare. Snowflake
+    participates through this structural contract and the NFR11
+    error-message tests, which both PASS (core validation raises before
+    sl_job is reached).
+    """
+
+    @pytest.mark.xfail(
+        raises=(ValueError, NotImplementedError),
+        strict=True,
+        reason="sl_import not implemented for Snowflake SQL executor",
+    )
+    def test_canonical_import_contract(self):
+        super().test_canonical_import_contract()
+
+    @pytest.mark.xfail(
+        raises=(ValueError, NotImplementedError),
+        strict=True,
+        reason="sl_pre_load/sl_import not implemented for Snowflake SQL executor",
+    )
+    def test_canonical_pre_load_chain(self):
+        super().test_canonical_pre_load_chain()


### PR DESCRIPTION
## Summary

Cross-orchestrator `sl_*` action behavior consistency: one shared canonical scenario contract asserted identically on every CI leg, runtime data equivalence for Airflow (2.10.5 and 3.3.0) and Dagster, and strict, orchestrator-named validation of `pre_load_strategy` values.

### Framework fix (Refs #63 — bug)

- New core classmethod `IStarlakeJob.sl_resolve_pre_load_strategy(value, default, action)`: `None`/`""` still resolve to the default (backward compatible); non-empty invalid strings now raise `ValueError` with the orchestrator name, the configuration key/action, the invalid value and the list of valid values.
- All four resolution sites now delegate to it:
  - `IStarlakeJob.__init__` (was: invalid option silently became `NONE`)
  - `IStarlakeJob.sl_pre_load` (was: invalid argument silently became the job default)
  - `StarlakeDagsterJob.sl_pre_load` (was: duplicated silent resolution)
  - `StarlakeAirflowJob.sl_pre_load` (was: `AttributeError: 'str' object has no attribute 'value'` for ANY string strategy — even valid ones — before validation could run; valid strings now work)
- `StarlakeSnowflakeJob` `NotImplementedError` for unsupported task types now names the orchestrator.
- No signature, enum, or import-path changes.

**Release note:** configs with a typo'd `pre_load_strategy` used to silently skip pre-loading (a data-correctness hazard); they now fail at DAG-build time with an actionable, orchestrator-named error.

### Tests

- `tests/shared/expected_results.py` — canonical contract: task IDs, CLI verb+flag contract, DuckDB row counts, full table/kpi snapshots (derived from a reference Starlake CLI 1.5.11 run, cross-checked against the sample CSVs), import-time drift guards.
- `tests/shared/base_test_sl_action_consistency.py` + concrete Airflow/Dagster/Snowflake subclasses — same scenario, same constants on every leg; equivalence is transitive through the shared contract.
- Airflow + Dagster runtime suites now assert the DuckDB state equals the canonical snapshots (same rows, not just counts) and consume `EXPECTED_ROW_COUNTS` instead of duplicated hard-coded counts. Snowflake is excluded from runtime data equivalence (SQL executor, mocked SDK) — documented in its test module; its two unimplemented-action tests follow the established strict xfail pattern.
- `tests/orchestration/test_pre_load_strategy_validation.py` — core unit tests for the strict resolution contract.

### Local verification (fresh isolated venvs, non-editable installs from branch source)

| Leg | Result |
| --- | --- |
| orchestration + shared (py3.9) | 125 passed |
| airflow-2.10.5 (py3.9) | 132 passed |
| airflow-3.3.0 (py3.12) | 123 passed, 9 pre-existing documented skips |
| dagster-1.9.13 (py3.9) | 93 passed |
| snowflake (py3.9) | 65 passed, 9 xfailed (7 pre-existing + 2 new documented) |

Closes #67
Refs #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)
