### PR TITLE
Story 3.5 — Cross-orchestrator cron scheduling validation

### DIFF
--- a/starlake-dagster/src/main/python/ai/starlake/dagster/starlake_dagster_orchestration.py
+++ b/starlake-dagster/src/main/python/ai/starlake/dagster/starlake_dagster_orchestration.py
@@ -178,7 +178,7 @@ class DagsterOrchestration(AbstractOrchestration[JobDefinition, OpDefinition, Gr
                     )
                 )
             elif cron:
-                crons.append(ScheduleDefinition(job_name = pipeline_id, cron_schedule = cron, default_status=DefaultScheduleStatus.RUNNING))
+                crons.append(ScheduleDefinition(job_name = pipeline_id, cron_schedule = cron, default_status=DefaultScheduleStatus.RUNNING, execution_timezone=self.job.timezone))
 
         defs = Definitions(
             assets=[AssetSpec(asset.uri) for pipeline in self.pipelines for asset in pipeline.assets],
@@ -496,7 +496,7 @@ class DagsterPipeline(AbstractPipeline[JobDefinition, OpDefinition, GraphDefinit
                     cron_schedule = cron,
                     start=self.start_date,
                     fmt=sl_timestamp_format,
-                    timezone='UTC',
+                    timezone=self.job.timezone,
                 ),
                 run_config_for_partition_fn=fun,
             )

--- a/tests/airflow/test_airflow_cron_scheduling.py
+++ b/tests/airflow/test_airflow_cron_scheduling.py
@@ -1,0 +1,105 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import pytest
+
+from ai.starlake.common import get_cron_frequency
+
+from tests.airflow.airflow_test_mixin import AirflowTestMixin
+from tests.shared.base_test_cron_scheduling import (
+    BaseTestCronScheduling,
+    COMMON_CRON_PATTERNS,
+)
+
+
+class TestAirflowCronScheduling(AirflowTestMixin, BaseTestCronScheduling):
+
+    def get_native_schedule(
+        self, pipeline, orchestration
+    ) -> Optional[Tuple[Optional[str], Optional[str]]]:
+        from ai.starlake.airflow.compat import supports_assets
+        dag = pipeline.dag
+        if supports_assets():  # Airflow 3
+            timetable = dag.timetable
+            expr = getattr(timetable, "expression", None)
+        else:  # Airflow 2
+            expr = dag.schedule_interval
+        if expr is None or not isinstance(expr, str):
+            # NullTimetable / dataset-triggered — unscheduled for our purposes
+            return None
+        # dag.timezone is a pendulum Timezone on both majors; its `name`
+        # is the IANA identifier
+        tz = getattr(dag.timezone, "name", str(dag.timezone))
+        return (expr, tz)
+
+    # -- Airflow-specific: data_interval semantics (AC #1) ----------------
+
+    @pytest.mark.parametrize("expr", COMMON_CRON_PATTERNS)
+    def test_data_interval_width_matches_cron_frequency(self, expr):
+        """The scheduler-side data interval for a cron schedule spans exactly
+        one cron period — the framework's canonical window
+        (scheduled_dates_range) has the same width by construction.
+
+        The two majors differ STRUCTURALLY here:
+        - Airflow 2.10: ``create_cron_data_intervals`` defaults to True, so
+          ``dag.timetable`` is ``airflow.timetables.interval.
+          CronDataIntervalTimetable`` and exposes
+          ``infer_manual_data_interval(*, run_after)`` directly.
+        - Airflow 3.3: ``create_cron_data_intervals`` defaults to False and
+          the sdk DAG builds ``airflow.sdk.definitions.timetables.trigger.
+          CronTriggerTimetable`` — a definition-only stub with NO
+          ``infer_manual_data_interval`` and NO ``next_dagrun_info``.
+          Interval computation lives scheduler-side in airflow-core, whose
+          ``airflow.timetables.interval.CronDataIntervalTimetable`` is still
+          importable and functional. We instantiate it from the DAG's own
+          (expression, timezone) to validate the scheduler-side
+          interpretation of the same cron.
+        """
+        from ai.starlake.airflow.compat import supports_assets
+        import pendulum
+        pipeline, _ = self._build_scheduled_pipeline(expr)
+        timetable = pipeline.dag.timetable
+        # Fixed run_after keeps the assertion deterministic — do NOT
+        # replace with pendulum.now().
+        run_after = pendulum.datetime(2026, 6, 15, 12, 0, 0, tz="UTC")
+        if supports_assets():  # Airflow 3
+            assert type(timetable).__name__ in (
+                "CronTriggerTimetable",
+                "CronDataIntervalTimetable",
+            ), f"Unexpected timetable {type(timetable).__name__}"
+            assert timetable.expression == expr
+            from airflow.timetables.interval import CronDataIntervalTimetable
+            core_timetable = CronDataIntervalTimetable(
+                expr, pipeline.dag.timezone
+            )
+            interval = core_timetable.infer_manual_data_interval(
+                run_after=run_after
+            )
+        else:  # Airflow 2
+            assert type(timetable).__name__ == "CronDataIntervalTimetable", (
+                f"Expected CronDataIntervalTimetable, "
+                f"got {type(timetable).__name__}"
+            )
+            interval = timetable.infer_manual_data_interval(
+                run_after=run_after
+            )
+        # pendulum.Interval subclasses datetime.timedelta, so equality with
+        # get_cron_frequency's timedelta is well-defined.
+        assert interval.end - interval.start == get_cron_frequency(expr)

--- a/tests/dagster/test_dagster_cron_scheduling.py
+++ b/tests/dagster/test_dagster_cron_scheduling.py
@@ -1,0 +1,96 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import pytest
+
+from ai.starlake.common import get_cron_frequency
+from ai.starlake.orchestration import StarlakeSchedule
+
+from tests.dagster.dagster_test_mixin import DagsterTestMixin
+from tests.shared.base_test_cron_scheduling import (
+    BaseTestCronScheduling,
+    COMMON_CRON_PATTERNS,
+)
+
+
+class TestDagsterCronScheduling(DagsterTestMixin, BaseTestCronScheduling):
+
+    def get_native_schedule(
+        self, pipeline, orchestration
+    ) -> Optional[Tuple[Optional[str], Optional[str]]]:
+        # JobDefinition + partitions are built in DagsterPipeline.__exit__ —
+        # the shared helper has already exited the pipeline context.
+        partitions_def = pipeline.dag.partitions_def
+        if partitions_def is None:
+            return None
+        return (partitions_def.cron_schedule, partitions_def.timezone)
+
+    # -- Dagster-specific: ScheduleDefinition registration (AC #1) --------
+
+    def _build_with_definitions(self, expr, options=None):
+        """``ScheduleDefinition`` is created in
+        ``DagsterOrchestration.__exit__`` — BOTH context managers must exit
+        before ``orch.definitions`` exists."""
+        with self.create_orchestration(options=options) as orch:
+            schedule = StarlakeSchedule(name=None, cron=expr, domains=[])
+            pipeline = orch.sl_create_pipeline(schedule=schedule)
+            with pipeline:
+                start = pipeline.start_task()
+                end = pipeline.end_task()
+                start >> end
+        return pipeline, orch
+
+    def test_cron_produces_schedule_definition(self):
+        expr = "0 2 * * *"
+        pipeline, orch = self._build_with_definitions(expr)
+        schedules = list(orch.definitions.schedules)
+        assert len(schedules) == 1, (
+            f"Expected 1 schedule, got {len(schedules)}"
+        )
+        sched = schedules[0]
+        assert sched.cron_schedule == expr
+        assert sched.job_name == pipeline.pipeline_id
+        # execution_timezone must be explicit (previously unset)
+        assert sched.execution_timezone == "UTC"
+
+    def test_schedule_definition_honors_configured_timezone(self):
+        _, orch = self._build_with_definitions(
+            "0 2 * * *", options={"timezone": "Europe/Paris"}
+        )
+        sched = list(orch.definitions.schedules)[0]
+        assert sched.execution_timezone == "Europe/Paris"
+
+    # -- Dagster-specific: partition window semantics (AC #1) -------------
+
+    @pytest.mark.parametrize("expr", COMMON_CRON_PATTERNS)
+    def test_partition_window_width_matches_cron_frequency(self, expr):
+        from datetime import timedelta
+        pipeline, _ = self._build_scheduled_pipeline(expr)
+        partitions_def = pipeline.dag.partitions_def
+        # start_date derives from the caller file's mtime ("today"), and
+        # get_partition_keys() at the DEFAULT current_time=now excludes the
+        # still-incomplete first window — daily/weekly/2am patterns would
+        # return ZERO keys on most runs. Pass an explicit far-future
+        # current_time to make every pattern deterministic.
+        current_time = pipeline.job.start_date + timedelta(days=60)
+        keys = partitions_def.get_partition_keys(current_time=current_time)
+        assert len(keys) > 0, "Expected at least one partition key"
+        window = partitions_def.time_window_for_partition_key(keys[0])
+        assert window.end - window.start == get_cron_frequency(expr)

--- a/tests/orchestration/test_cron_scheduling.py
+++ b/tests/orchestration/test_cron_scheduling.py
@@ -354,3 +354,32 @@ class TestStarlakeDependencyToDataset:
         dataset = dep.to_dataset()
         assert dataset.freshness == 3600
         assert dataset.cron is not None
+
+
+# ---------------------------------------------------------------------------
+# 4.12  Timezone equivalence of the core scheduling helpers
+# ---------------------------------------------------------------------------
+
+class TestScheduledDateTimezoneEquivalence:
+    """The same instant expressed in different timezones yields the same
+    scheduled date from the core helpers — timezone handling is consistent
+    across orchestrators because they all share these helpers."""
+
+    def test_same_instant_two_timezones_same_scheduled_date(self):
+        from ai.starlake.common import sl_scheduled_date
+        # 12:30 UTC == 14:30 Paris (CEST, June)
+        utc_result = sl_scheduled_date(
+            "0 2 * * *", "2025-06-15T12:30:00+00:00"
+        )
+        paris_result = sl_scheduled_date(
+            "0 2 * * *", "2025-06-15T14:30:00+02:00"
+        )
+        assert utc_result == paris_result
+
+    def test_scheduled_dates_range_is_timezone_aware(self):
+        paris = pytz.timezone("Europe/Paris")
+        ts = paris.localize(datetime(2025, 6, 15, 14, 30, 0))
+        start, end = scheduled_dates_range("0 2 * * *", ts)
+        assert start.tzinfo is not None
+        assert end.tzinfo is not None
+        assert start < end

--- a/tests/shared/base_test_cron_scheduling.py
+++ b/tests/shared/base_test_cron_scheduling.py
@@ -1,0 +1,162 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import sys
+from abc import abstractmethod
+from typing import Optional, Tuple
+
+import pytest
+
+from ai.starlake.orchestration import (
+    AbstractOrchestration,
+    AbstractPipeline,
+    StarlakeDependencies,
+    StarlakeDependency,
+    StarlakeDependencyType,
+    StarlakeSchedule,
+)
+
+from tests.shared.base_test_orchestration import BaseTestOrchestration
+
+
+# The portable cron subset: standard 5-field expressions.
+# (croniter also accepts @-aliases and 6-field second-resolution crons,
+# but Snowflake's USING CRON only supports 5-field syntax — the portable
+# contract across all orchestrators is therefore the standard 5-field
+# expression. DAG configs must stick to 5-field expressions.)
+COMMON_CRON_PATTERNS = [
+    pytest.param("0 * * * *", id="hourly"),
+    pytest.param("0 0 * * *", id="daily"),
+    pytest.param("0 0 * * 0", id="weekly"),
+    pytest.param("0 2 * * *", id="custom-daily-2am"),
+    pytest.param("*/15 * * * *", id="custom-every-15min"),
+]
+
+INVALID_CRON_PATTERNS = [
+    pytest.param("not_a_cron", id="garbage"),
+    pytest.param("60 * * * *", id="minute-out-of-range"),
+    pytest.param("0 0 * *", id="too-few-fields"),
+]
+
+
+class BaseTestCronScheduling(BaseTestOrchestration):
+    """Shared cron-scheduling consistency tests (cross-orchestrator).
+
+    Concrete subclasses provide ``get_native_schedule()`` on top of the
+    three abstract methods from ``BaseTestOrchestration`` (all three come
+    from the orchestrator's existing test mixin).
+    """
+
+    @abstractmethod
+    def get_native_schedule(
+        self,
+        pipeline: AbstractPipeline,
+        orchestration: AbstractOrchestration,
+    ) -> Optional[Tuple[Optional[str], Optional[str]]]:
+        """Return ``(cron_expr, timezone_name)`` from the orchestrator's
+        NATIVE scheduling construct, or ``None`` when the pipeline is
+        unscheduled.
+
+        - Airflow:   (timetable expression, str(dag.timezone))
+        - Dagster:   (partitions_def.cron_schedule, partitions_def.timezone)
+        - Snowflake: (dag.schedule.expr, dag.schedule.timezone)
+        """
+
+    # -- helpers ---------------------------------------------------------
+
+    def _build_scheduled_pipeline(
+        self, cron: Optional[str], options: Optional[dict] = None
+    ) -> Tuple[AbstractPipeline, AbstractOrchestration]:
+        """Full orchestration → pipeline path with a populated task graph."""
+        orchestration = self.create_orchestration(options=options)
+        schedule = StarlakeSchedule(name=None, cron=cron, domains=[])
+        pipeline = orchestration.sl_create_pipeline(schedule=schedule)
+        with pipeline:
+            start = pipeline.start_task()
+            end = pipeline.end_task()
+            start >> end
+        return pipeline, orchestration
+
+    # -- AC #1 / #4: common patterns propagate verbatim ------------------
+
+    @pytest.mark.parametrize("expr", COMMON_CRON_PATTERNS)
+    def test_cron_pattern_propagates_to_native_schedule(self, expr):
+        pipeline, orchestration = self._build_scheduled_pipeline(expr)
+        assert pipeline.cron == expr
+        assert pipeline.computed_cron_expr == expr
+        native = self.get_native_schedule(pipeline, orchestration)
+        assert native is not None, (
+            f"Expected a native schedule for cron {expr!r}, got None"
+        )
+        native_expr, native_tz = native
+        assert native_expr == expr, (
+            f"Native schedule carries {native_expr!r}, expected {expr!r}"
+        )
+        # Default job timezone is UTC (core IStarlakeJob 'timezone' option)
+        assert native_tz == "UTC", (
+            f"Native timezone is {native_tz!r}, expected 'UTC'"
+        )
+
+    # -- AC #2: invalid crons rejected (schedule path) --------------------
+
+    @pytest.mark.parametrize("expr", INVALID_CRON_PATTERNS)
+    def test_invalid_cron_rejected_at_schedule_construction(self, expr):
+        with pytest.raises(ValueError, match="Invalid cron expression"):
+            StarlakeSchedule(name="bad", cron=expr, domains=[])
+
+    # -- AC #2: invalid crons rejected (DAG-globals / dependencies path) --
+
+    def test_invalid_cron_in_dag_globals_rejected(self, monkeypatch):
+        """``AbstractPipeline.__init__`` validates the caller-module ``cron``
+        global in dependencies mode, before any orchestrator construct is
+        built."""
+        orchestration = self.create_orchestration()
+        caller_module = sys.modules[orchestration.job.caller_module_name]
+        monkeypatch.setattr(caller_module, "cron", "not_a_cron", raising=False)
+        dependencies = StarlakeDependencies([
+            StarlakeDependency(
+                name="starbake.orders",
+                dependency_type=StarlakeDependencyType.TABLE,
+            ),
+        ])
+        with pytest.raises(ValueError, match="Invalid cron expression"):
+            orchestration.sl_create_pipeline(dependencies=dependencies)
+
+    # -- unscheduled pipeline ---------------------------------------------
+
+    def test_no_cron_produces_unscheduled_pipeline(self):
+        pipeline, orchestration = self._build_scheduled_pipeline(None)
+        assert pipeline.cron is None
+        assert self.get_native_schedule(pipeline, orchestration) is None
+
+    # -- AC #3: timezone consistency --------------------------------------
+
+    def test_default_timezone_is_utc(self):
+        pipeline, orchestration = self._build_scheduled_pipeline("0 2 * * *")
+        assert pipeline.job.timezone == "UTC"
+        _, native_tz = self.get_native_schedule(pipeline, orchestration)
+        assert native_tz == "UTC"
+
+    def test_configured_timezone_propagates(self):
+        """A non-UTC ``timezone`` option must reach the native construct."""
+        pipeline, orchestration = self._build_scheduled_pipeline(
+            "0 2 * * *", options={"timezone": "Europe/Paris"}
+        )
+        assert pipeline.job.timezone == "Europe/Paris"
+        _, native_tz = self.get_native_schedule(pipeline, orchestration)
+        assert native_tz == "Europe/Paris"

--- a/tests/snowflake/test_snowflake_cron_scheduling.py
+++ b/tests/snowflake/test_snowflake_cron_scheduling.py
@@ -1,0 +1,45 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Optional, Tuple
+
+from snowflake.core.task import Cron
+
+from tests.snowflake.snowflake_test_mixin import SnowflakeTestMixin
+from tests.shared.base_test_cron_scheduling import BaseTestCronScheduling
+
+
+class TestSnowflakeCronScheduling(SnowflakeTestMixin, BaseTestCronScheduling):
+
+    def get_native_schedule(
+        self, pipeline, orchestration
+    ) -> Optional[Tuple[Optional[str], Optional[str]]]:
+        schedule = pipeline.dag.schedule
+        if isinstance(schedule, Cron):
+            return (schedule.expr, schedule.timezone)
+        return None  # timedelta fallback == unscheduled
+
+    # -- Snowflake-specific: no-cron fallback (AC #1) ----------------------
+
+    def test_no_cron_falls_back_to_min_timedelta(self):
+        """``SnowflakeDag`` defaults to
+        ``timedelta(seconds=min_timedelta_between_runs)`` when no cron is
+        provided (job default 900s)."""
+        pipeline, _ = self._build_scheduled_pipeline(None)
+        assert pipeline.dag.schedule == timedelta(seconds=900)


### PR DESCRIPTION
## Summary

Validates that cron expressions are validated once (core, croniter) and produce consistent scheduling semantics across all orchestrators — Airflow 2.10.5, Airflow 3.3.0, Dagster 1.9.13, Snowflake — and fixes the one real divergence found: Dagster ignored the shared `timezone` option.

### Framework fix (Refs #69)

`starlake-dagster`: `TimeWindowPartitionsDefinition(timezone=self.job.timezone)` + `ScheduleDefinition(..., execution_timezone=self.job.timezone)`. Default `'UTC'` keeps current behavior byte-identical; a configured non-UTC `timezone` now yields the same schedule on all three orchestrators. Red-green verified (3 timezone tests failed before the fix). Release note: an invalid `timezone` string now fails at Dagster definition time instead of being silently ignored (parity with Airflow's pytz raise).

### Tests

- NEW `tests/shared/base_test_cron_scheduling.py` — ninth shared base; single new abstract `get_native_schedule(pipeline, orchestration) -> Optional[(expr, tz)]`. Covers verbatim propagation of hourly/daily/weekly/custom patterns, invalid-cron rejection on both the schedule and DAG-globals paths, unscheduled (no-cron) pipelines, default-UTC and configured-timezone propagation.
- NEW `tests/airflow/test_airflow_cron_scheduling.py` — + scheduler-side data-interval width == cron period on BOTH majors (Airflow 3's sdk `CronTriggerTimetable` is definition-only, so the core `CronDataIntervalTimetable` is instantiated from the DAG's own expression/timezone).
- NEW `tests/dagster/test_dagster_cron_scheduling.py` — + `ScheduleDefinition` registration (cron/job_name/execution_timezone) and partition window width (explicit `current_time` for determinism).
- NEW `tests/snowflake/test_snowflake_cron_scheduling.py` — + no-cron `timedelta(seconds=900)` fallback.
- `tests/orchestration/test_cron_scheduling.py` — appended `TestScheduledDateTimezoneEquivalence` (same instant in two timezones → same scheduled date).

Portable cron contract documented: standard 5-field expressions (croniter also accepts @-aliases/6-field crons that Snowflake USING CRON cannot execute).

### Local verification (fresh py3.11 venvs, non-editable installs from source, CI-mirroring order)

| Leg | Result |
|---|---|
| orchestration + shared | 116 passed |
| airflow 2.10.5 | 141 passed |
| airflow 3.3.0 | 132 passed + 9 pre-existing skips |
| dagster 1.9.13 | 104 passed |
| snowflake | 74 passed + 7 pre-existing xfails |

Closes #71
Refs #69

Sibling PRs (Epic 3): #66, #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)