### PR TITLE
Story 3.2 — Cross-orchestrator Jinja2 template rendering validation

### DIFF
--- a/tests/airflow/test_airflow_parser_validation.py
+++ b/tests/airflow/test_airflow_parser_validation.py
@@ -1,0 +1,104 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""AC3 / NFR8 — generated DAGs are valid for Airflow's parser (2.x AND 3.x).
+
+Full chain: ``starlake dag-generate`` (shared ``runtime_dags`` fixture)
+→ generated ``.py`` files → Airflow's filesystem ``DagBag``.
+
+Filesystem DagBag parsing needs NO metadata DB, bundle config, or
+``DAG.bulk_write_to_db`` — none of the runtime-suite Airflow 3 gotchas
+apply, so this module must NOT carry any 2.x-only skip: it runs
+un-skipped on BOTH CI legs (Product Decision 3 of the story).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.shared.conftest import restore_env, set_env
+from tests.shared.template_test_utils import assert_dag_generate_idempotent
+
+try:
+    import airflow
+
+    AIRFLOW_AVAILABLE = True
+    AIRFLOW_VERSION = tuple(int(x) for x in airflow.__version__.split(".")[:2])
+    if AIRFLOW_VERSION >= (3, 0):
+        # airflow.models.dagbag.DagBag is a DeprecatedImportWarning shim on 3.x;
+        # the filesystem DagBag moved to airflow.dag_processing.dagbag.
+        from airflow.dag_processing.dagbag import DagBag
+    else:
+        from airflow.models.dagbag import DagBag
+except ImportError:
+    AIRFLOW_AVAILABLE = False
+    AIRFLOW_VERSION = (0, 0)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not AIRFLOW_AVAILABLE, reason="Requires Apache Airflow"),
+]
+
+
+@pytest.fixture(scope="module")
+def dagbag(runtime_dags, airflow_home):
+    """Parse the dag-generate output directory through Airflow's DagBag.
+
+    Env vars from runtime_dags (SL_ROOT, LOAD_DAG_REF, ...) must be live while
+    DagBag imports the generated modules, exactly as for load_pipelines().
+    ``safe_mode=False`` because the generated files do not necessarily contain
+    the literal heuristic strings DagBag greps for before importing.
+    """
+    dags_dir, _isolated, env = runtime_dags
+    original = set_env(env)
+    try:
+        if AIRFLOW_VERSION >= (3, 0):
+            bag = DagBag(dag_folder=str(dags_dir), safe_mode=False, collect_dags=True)
+        else:
+            bag = DagBag(
+                dag_folder=str(dags_dir), include_examples=False, safe_mode=False
+            )
+    finally:
+        restore_env(original)
+    return bag
+
+
+class TestAirflowDagBagValidation:
+    """AC3 / NFR8 — generated DAGs are valid for Airflow's parser (2.x AND 3.x)."""
+
+    def test_dagbag_has_no_import_errors(self, dagbag):
+        assert dagbag.import_errors == {}, (
+            f"DagBag import errors: {dagbag.import_errors}"
+        )
+
+    def test_dagbag_collected_generated_dags(self, dagbag, runtime_dags):
+        dags_dir, _, _ = runtime_dags
+        generated_files = sorted(dags_dir.glob("*.py"))
+        assert len(generated_files) > 0
+        assert len(dagbag.dags) >= 1, (
+            f"DagBag collected no DAGs from {len(generated_files)} generated files"
+        )
+
+    def test_dagbag_dags_have_tasks(self, dagbag):
+        for dag_id, dag in dagbag.dags.items():
+            assert len(dag.tasks) > 0, f"DAG {dag_id} parsed with zero tasks"
+
+
+class TestAirflowDagGenerateIdempotence:
+    """AC2 / NFR2 — dag-generate output is byte-identical across runs."""
+
+    def test_dag_generate_is_idempotent(self, runtime_dags, tmp_path_factory):
+        assert_dag_generate_idempotent(runtime_dags, tmp_path_factory)

--- a/tests/airflow/test_airflow_templates.py
+++ b/tests/airflow/test_airflow_templates.py
@@ -17,18 +17,16 @@
 from __future__ import annotations
 
 import ast
-from pathlib import Path
 
 import pytest
-from jinja2 import Environment, FileSystemLoader, TemplateSyntaxError
+from jinja2 import TemplateSyntaxError
 
-# ---------------------------------------------------------------------------
-# Template search paths — templates include files from multiple modules
-# ---------------------------------------------------------------------------
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[2]
-_AIRFLOW_RESOURCES = _PROJECT_ROOT / "starlake-airflow" / "src" / "main" / "resources"
-_ORCH_RESOURCES = _PROJECT_ROOT / "starlake-orchestration" / "src" / "main" / "resources"
+from tests.shared.template_test_utils import (
+    MODULE_RESOURCES,
+    make_jinja_env,
+    make_mock_context,
+    parse_header_options,
+)
 
 _SHELL_LOAD_TEMPLATE = "templates/dags/load/airflow__scheduled_table__shell.py.j2"
 _SHELL_TRANSFORM_TEMPLATE = "templates/dags/transform/airflow__scheduled_task__shell.py.j2"
@@ -37,64 +35,7 @@ _SHELL_TRANSFORM_TEMPLATE = "templates/dags/transform/airflow__scheduled_task__s
 @pytest.fixture(scope="module")
 def jinja_env():
     """Jinja2 environment with search paths covering both Airflow and core modules."""
-    return Environment(
-        loader=FileSystemLoader([str(_AIRFLOW_RESOURCES), str(_ORCH_RESOURCES)]),
-        keep_trailing_newline=True,
-    )
-
-
-def _make_mock_context():
-    """Build a minimal mock context matching what ``starlake dag-generate`` provides."""
-
-    class _Option:
-        def __init__(self, name, value):
-            self.name = name
-            self.value = value
-
-    class _Table:
-        def __init__(self, name):
-            self.name = name
-            self.final_name = name
-
-    class _Domain:
-        def __init__(self, name, tables):
-            self.name = name
-            self.final_name = name
-            self.tables = [_Table(t) for t in tables]
-
-    class _Schedule:
-        def __init__(self, schedule, cron, domains):
-            self.schedule = schedule
-            self.cron = cron
-            self.domains = [_Domain(d, tables) for d, tables in domains.items()]
-
-    class _Config:
-        def __init__(self):
-            self.comment = "Test DAG for loading starbake tables"
-            self.template = "load/airflow__scheduled_table__shell.py.j2"
-            self.options = [
-                _Option("SL_ROOT", "/tmp/test"),
-                _Option("SL_ENV", "DUCKDB"),
-                _Option("SL_STARLAKE_PATH", "starlake"),
-                _Option("pre_load_strategy", "imported"),
-                _Option("tags", "starbake"),
-            ]
-
-    class _Context:
-        def __init__(self):
-            self.config = _Config()
-            self.sl_airflow_access_control = "None"
-            self.cron = "0 0 * * *"
-            self.schedules = [
-                _Schedule(
-                    schedule="daily",
-                    cron="0 0 * * *",
-                    domains={"starbake": ["customers", "orders", "products"]},
-                ),
-            ]
-            self.dependencies = "[]"
-
-    return _Context()
+    return make_jinja_env("airflow")
 
 
 # ------------------------------------------------------------------
@@ -120,7 +61,7 @@ class TestAirflowTemplates:
     def test_load_template_renders_valid_python(self, jinja_env):
         """Render load template with mock variables and verify valid Python."""
         template = jinja_env.get_template(_SHELL_LOAD_TEMPLATE)
-        rendered = template.render(context=_make_mock_context())
+        rendered = template.render(context=make_mock_context("airflow"))
         try:
             ast.parse(rendered)
         except SyntaxError as exc:
@@ -131,9 +72,11 @@ class TestAirflowTemplates:
 
     def test_transform_template_renders_valid_python(self, jinja_env):
         """Render transform template with mock variables and verify valid Python."""
-        context = _make_mock_context()
-        context.config.comment = "Test DAG for transforming starbake tasks"
-        context.config.template = "transform/airflow__scheduled_task__shell.py.j2"
+        context = make_mock_context(
+            "airflow",
+            template="transform/airflow__scheduled_task__shell.py.j2",
+            comment="Test DAG for transforming starbake tasks",
+        )
         template = jinja_env.get_template(_SHELL_TRANSFORM_TEMPLATE)
         rendered = template.render(context=context)
         try:
@@ -143,3 +86,107 @@ class TestAirflowTemplates:
                 f"Rendered transform template is not valid Python: {exc}\n"
                 f"--- rendered output ---\n{rendered[:500]}"
             )
+
+
+# ------------------------------------------------------------------
+# Story 3.2 — AC1 snippet composition
+# ------------------------------------------------------------------
+
+class TestAirflowTemplateComposition:
+    """AC1 — snippet composition is visible in the rendered output."""
+
+    def test_load_template_composes_orchestrator_snippet(self, jinja_env):
+        rendered = jinja_env.get_template(_SHELL_LOAD_TEMPLATE).render(
+            context=make_mock_context("airflow")
+        )
+        # __starlake_airflow_orchestrator.py.j2 — enum + airflow-specific vars
+        assert "orchestrator = StarlakeOrchestrator.AIRFLOW" in rendered
+        assert "access_control = None" in rendered
+        assert "default_dag_args = dict(__dag_args, **DEFAULT_DAG_ARGS)" in rendered
+        # __starlake_shell_execution.py — execution environment
+        assert "execution_environment = StarlakeExecutionEnvironment.SHELL" in rendered
+        # __common__.py.j2 — config projection
+        assert 'description="""Test DAG for loading starbake tables"""' in rendered
+        assert 'template="load/airflow__scheduled_table__shell.py.j2"' in rendered
+        assert "'SL_STARLAKE_PATH':'starlake'" in rendered
+        # load/__scheduled_table_tpl.py.j2 — shared pipeline logic
+        assert (
+            "with OrchestrationFactory.create_orchestration(job=sl_job) as orchestration:"
+            in rendered
+        )
+        assert "pipelines = [generate_pipeline(schedule) for schedule in schedules]" in rendered
+
+    def test_transform_template_composes_orchestrator_snippet(self, jinja_env):
+        context = make_mock_context(
+            "airflow",
+            template="transform/airflow__scheduled_task__shell.py.j2",
+            comment="Test DAG for transforming starbake tasks",
+        )
+        rendered = jinja_env.get_template(_SHELL_TRANSFORM_TEMPLATE).render(context=context)
+        assert "orchestrator = StarlakeOrchestrator.AIRFLOW" in rendered
+        assert "execution_environment = StarlakeExecutionEnvironment.SHELL" in rendered
+        # transform/__scheduled_task_tpl.py.j2 — dependency-driven pipeline logic
+        assert 'cron = "0 0 * * *"' in rendered
+        assert 'dependencies=StarlakeDependencies(dependencies="""[]"""' in rendered
+
+
+# ------------------------------------------------------------------
+# Story 3.2 — AC2 / NFR2 render idempotence
+# ------------------------------------------------------------------
+
+class TestAirflowTemplateIdempotence:
+    """AC2 / NFR2 — byte-identical re-render at the Python-Jinja2 layer."""
+
+    @pytest.mark.parametrize(
+        "template_name", [_SHELL_LOAD_TEMPLATE, _SHELL_TRANSFORM_TEMPLATE]
+    )
+    def test_render_is_byte_identical(self, jinja_env, template_name):
+        template = jinja_env.get_template(template_name)
+        first = template.render(context=make_mock_context("airflow"))
+        second = template.render(context=make_mock_context("airflow"))
+        # And from a completely fresh Environment (no loader/cache state):
+        third = make_jinja_env("airflow").get_template(template_name).render(
+            context=make_mock_context("airflow")
+        )
+        assert first == second
+        assert first.encode("utf-8") == third.encode("utf-8"), (
+            f"{template_name} render is not idempotent across environments (NFR2)"
+        )
+
+
+# ------------------------------------------------------------------
+# Story 3.2 — AC4 self-documenting headers
+# ------------------------------------------------------------------
+
+class TestAirflowTemplateHeaderOptions:
+    """AC4 — header comments document the options (existing convention).
+
+    CLI-parseability of every ``# - `` line is enforced globally by the
+    shared convention test (tests/shared/test_template_conventions.py).
+    """
+
+    def test_load_template_header_documents_known_options(self):
+        path = (
+            MODULE_RESOURCES["airflow"]
+            / "templates" / "dags" / "load" / "airflow__scheduled_table__shell.py.j2"
+        )
+        options = parse_header_options(path)
+        expected = {
+            "sl_env_var", "SL_STARLAKE_PATH", "pre_load_strategy",
+            "global_ack_file_path", "ack_wait_timeout", "default_dag_args",
+        }
+        missing = expected - set(options)
+        assert not missing, f"Load template header no longer documents: {missing}"
+
+    def test_transform_template_header_documents_known_options(self):
+        path = (
+            MODULE_RESOURCES["airflow"]
+            / "templates" / "dags" / "transform" / "airflow__scheduled_task__shell.py.j2"
+        )
+        options = parse_header_options(path)
+        expected = {
+            "sl_env_var", "SL_STARLAKE_PATH",
+            "dataset_triggering_strategy", "default_dag_args",
+        }
+        missing = expected - set(options)
+        assert not missing, f"Transform template header no longer documents: {missing}"

--- a/tests/dagster/test_dagster_parser_validation.py
+++ b/tests/dagster/test_dagster_parser_validation.py
@@ -1,0 +1,103 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""AC3 / NFR8 — generated modules load as Dagster Definitions.
+
+Full chain: ``starlake dag-generate`` (shared ``runtime_dags`` fixture)
+→ generated ``.py`` files → ``load_pipelines()`` → module-bound ``defs``
+→ ``Definitions.validate_loadable`` (the same resolution Dagster performs
+when loading a code location).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from tests.shared.conftest import restore_env, set_env
+from tests.shared.template_test_utils import assert_dag_generate_idempotent
+
+pytestmark = [pytest.mark.integration]
+
+
+@pytest.fixture(scope="module")
+def loaded_definitions(runtime_dags):
+    """load_pipelines() each generated file and collect the module-bound defs.
+
+    DagsterOrchestration.__exit__ binds Definitions to the caller module:
+    ``setattr(module, 'defs', defs)`` (starlake_dagster_orchestration.py:196),
+    and load_pipelines registers the module as sys.modules[<file stem>]
+    (ai/starlake/orchestration/__main__.py:26-30).
+    """
+    from ai.starlake.orchestration.__main__ import load_pipelines
+
+    dags_dir, _isolated, env = runtime_dags
+    original = set_env(env)
+    try:
+        all_defs = {}
+        for py_file in sorted(dags_dir.glob("*.py")):
+            pipelines = load_pipelines(str(py_file))
+            assert pipelines, f"No pipelines loaded from {py_file.name}"
+            module = sys.modules[py_file.stem]
+            assert hasattr(module, "defs"), (
+                f"{py_file.name} has no module-level 'defs' — repository "
+                f"loading contract broken"
+            )
+            all_defs[py_file.name] = module.defs
+    finally:
+        restore_env(original)
+    assert len(all_defs) > 0
+    return all_defs
+
+
+class TestDagsterRepositoryLoading:
+    """AC3 / NFR8 — generated modules load as Dagster Definitions."""
+
+    def test_defs_are_definitions_instances(self, loaded_definitions):
+        from dagster import Definitions
+
+        for name, defs in loaded_definitions.items():
+            assert isinstance(defs, Definitions), f"{name}: {type(defs)}"
+
+    def test_definitions_are_loadable(self, loaded_definitions):
+        from dagster import Definitions
+
+        for name, defs in loaded_definitions.items():
+            # Same resolution Dagster performs when loading a code location.
+            Definitions.validate_loadable(defs)
+
+    def test_definitions_expose_jobs(self, loaded_definitions):
+        for name, defs in loaded_definitions.items():
+            # Dagster auto-adds an IMPLICIT asset job ("__ASSET_JOB", see
+            # dagster._core.definitions.asset_job.IMPLICIT_ASSET_JOB_NAME)
+            # to Definitions that carry asset defs (the transform pipeline's
+            # upstream datasets) — it legitimately has zero ops. Only the
+            # generated PIPELINE jobs must have ops.
+            pipeline_jobs = [
+                job for job in defs.get_all_job_defs()
+                if not job.name.startswith("__ASSET_JOB")
+            ]
+            assert len(pipeline_jobs) > 0, f"{name} exposes no pipeline jobs"
+            for job in pipeline_jobs:
+                assert len(job.nodes) > 0, f"{name}:{job.name} has no ops"
+
+
+class TestDagsterDagGenerateIdempotence:
+    """AC2 / NFR2 — dag-generate output is byte-identical across runs."""
+
+    def test_dag_generate_is_idempotent(self, runtime_dags, tmp_path_factory):
+        assert_dag_generate_idempotent(runtime_dags, tmp_path_factory)

--- a/tests/dagster/test_dagster_templates.py
+++ b/tests/dagster/test_dagster_templates.py
@@ -17,18 +17,16 @@
 from __future__ import annotations
 
 import ast
-from pathlib import Path
 
 import pytest
-from jinja2 import Environment, FileSystemLoader, TemplateSyntaxError
+from jinja2 import TemplateSyntaxError
 
-# ---------------------------------------------------------------------------
-# Template search paths — templates include files from multiple modules
-# ---------------------------------------------------------------------------
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[2]
-_DAGSTER_RESOURCES = _PROJECT_ROOT / "starlake-dagster" / "src" / "main" / "resources"
-_ORCH_RESOURCES = _PROJECT_ROOT / "starlake-orchestration" / "src" / "main" / "resources"
+from tests.shared.template_test_utils import (
+    MODULE_RESOURCES,
+    make_jinja_env,
+    make_mock_context,
+    parse_header_options,
+)
 
 _SHELL_LOAD_TEMPLATE = "templates/dags/load/dagster__scheduled_table__shell.py.j2"
 _SHELL_TRANSFORM_TEMPLATE = "templates/dags/transform/dagster__scheduled_task__shell.py.j2"
@@ -37,63 +35,7 @@ _SHELL_TRANSFORM_TEMPLATE = "templates/dags/transform/dagster__scheduled_task__s
 @pytest.fixture(scope="module")
 def jinja_env():
     """Jinja2 environment with search paths covering both Dagster and core modules."""
-    return Environment(
-        loader=FileSystemLoader([str(_DAGSTER_RESOURCES), str(_ORCH_RESOURCES)]),
-        keep_trailing_newline=True,
-    )
-
-
-def _make_mock_context():
-    """Build a minimal mock context matching what ``starlake dag-generate`` provides."""
-
-    class _Option:
-        def __init__(self, name, value):
-            self.name = name
-            self.value = value
-
-    class _Table:
-        def __init__(self, name):
-            self.name = name
-            self.final_name = name
-
-    class _Domain:
-        def __init__(self, name, tables):
-            self.name = name
-            self.final_name = name
-            self.tables = [_Table(t) for t in tables]
-
-    class _Schedule:
-        def __init__(self, schedule, cron, domains):
-            self.schedule = schedule
-            self.cron = cron
-            self.domains = [_Domain(d, tables) for d, tables in domains.items()]
-
-    class _Config:
-        def __init__(self):
-            self.comment = "Test DAG for loading starbake tables"
-            self.template = "load/dagster__scheduled_table__shell.py.j2"
-            self.options = [
-                _Option("SL_ROOT", "/tmp/test"),
-                _Option("SL_ENV", "DUCKDB"),
-                _Option("SL_STARLAKE_PATH", "starlake"),
-                _Option("pre_load_strategy", "imported"),
-                _Option("tags", "starbake"),
-            ]
-
-    class _Context:
-        def __init__(self):
-            self.config = _Config()
-            self.cron = "0 0 * * *"
-            self.schedules = [
-                _Schedule(
-                    schedule="daily",
-                    cron="0 0 * * *",
-                    domains={"starbake": ["customers", "orders", "products"]},
-                ),
-            ]
-            self.dependencies = "[]"
-
-    return _Context()
+    return make_jinja_env("dagster")
 
 
 # ------------------------------------------------------------------
@@ -119,7 +61,7 @@ class TestDagsterTemplates:
     def test_load_template_renders_valid_python(self, jinja_env):
         """Render load template with mock variables and verify valid Python."""
         template = jinja_env.get_template(_SHELL_LOAD_TEMPLATE)
-        rendered = template.render(context=_make_mock_context())
+        rendered = template.render(context=make_mock_context("dagster"))
         try:
             ast.parse(rendered)
         except SyntaxError as exc:
@@ -130,9 +72,11 @@ class TestDagsterTemplates:
 
     def test_transform_template_renders_valid_python(self, jinja_env):
         """Render transform template with mock variables and verify valid Python."""
-        context = _make_mock_context()
-        context.config.comment = "Test DAG for transforming starbake tasks"
-        context.config.template = "transform/dagster__scheduled_task__shell.py.j2"
+        context = make_mock_context(
+            "dagster",
+            template="transform/dagster__scheduled_task__shell.py.j2",
+            comment="Test DAG for transforming starbake tasks",
+        )
         template = jinja_env.get_template(_SHELL_TRANSFORM_TEMPLATE)
         rendered = template.render(context=context)
         try:
@@ -142,3 +86,113 @@ class TestDagsterTemplates:
                 f"Rendered transform template is not valid Python: {exc}\n"
                 f"--- rendered output ---\n{rendered[:500]}"
             )
+
+
+# ------------------------------------------------------------------
+# Story 3.2 — AC1 snippet composition
+# ------------------------------------------------------------------
+
+class TestDagsterTemplateComposition:
+    """AC1 — snippet composition is visible in the rendered output.
+
+    The Dagster snippet sets ONLY the orchestrator enum (verified) —
+    the negative assertions pin that snippet contract.
+    """
+
+    def test_load_template_composes_orchestrator_snippet(self, jinja_env):
+        rendered = jinja_env.get_template(_SHELL_LOAD_TEMPLATE).render(
+            context=make_mock_context("dagster")
+        )
+        # __starlake_dagster_orchestrator.py.j2 — enum ONLY
+        assert "orchestrator = StarlakeOrchestrator.DAGSTER" in rendered
+        assert "access_control" not in rendered
+        assert "default_dag_args" not in rendered
+        # __starlake_shell_execution.py — execution environment
+        assert "execution_environment = StarlakeExecutionEnvironment.SHELL" in rendered
+        # __common__.py.j2 — config projection
+        assert 'description="""Test DAG for loading starbake tables"""' in rendered
+        assert 'template="load/dagster__scheduled_table__shell.py.j2"' in rendered
+        assert "'SL_STARLAKE_PATH':'starlake'" in rendered
+        # load/__scheduled_table_tpl.py.j2 — shared pipeline logic
+        assert (
+            "with OrchestrationFactory.create_orchestration(job=sl_job) as orchestration:"
+            in rendered
+        )
+        assert "pipelines = [generate_pipeline(schedule) for schedule in schedules]" in rendered
+
+    def test_transform_template_composes_orchestrator_snippet(self, jinja_env):
+        context = make_mock_context(
+            "dagster",
+            template="transform/dagster__scheduled_task__shell.py.j2",
+            comment="Test DAG for transforming starbake tasks",
+        )
+        rendered = jinja_env.get_template(_SHELL_TRANSFORM_TEMPLATE).render(context=context)
+        assert "orchestrator = StarlakeOrchestrator.DAGSTER" in rendered
+        assert "access_control" not in rendered
+        assert "default_dag_args" not in rendered
+        assert "execution_environment = StarlakeExecutionEnvironment.SHELL" in rendered
+        # transform/__scheduled_task_tpl.py.j2 — dependency-driven pipeline logic
+        assert 'cron = "0 0 * * *"' in rendered
+        assert 'dependencies=StarlakeDependencies(dependencies="""[]"""' in rendered
+
+
+# ------------------------------------------------------------------
+# Story 3.2 — AC2 / NFR2 render idempotence
+# ------------------------------------------------------------------
+
+class TestDagsterTemplateIdempotence:
+    """AC2 / NFR2 — byte-identical re-render at the Python-Jinja2 layer."""
+
+    @pytest.mark.parametrize(
+        "template_name", [_SHELL_LOAD_TEMPLATE, _SHELL_TRANSFORM_TEMPLATE]
+    )
+    def test_render_is_byte_identical(self, jinja_env, template_name):
+        template = jinja_env.get_template(template_name)
+        first = template.render(context=make_mock_context("dagster"))
+        second = template.render(context=make_mock_context("dagster"))
+        # And from a completely fresh Environment (no loader/cache state):
+        third = make_jinja_env("dagster").get_template(template_name).render(
+            context=make_mock_context("dagster")
+        )
+        assert first == second
+        assert first.encode("utf-8") == third.encode("utf-8"), (
+            f"{template_name} render is not idempotent across environments (NFR2)"
+        )
+
+
+# ------------------------------------------------------------------
+# Story 3.2 — AC4 self-documenting headers
+# ------------------------------------------------------------------
+
+class TestDagsterTemplateHeaderOptions:
+    """AC4 — header comments document the options (existing convention).
+
+    CLI-parseability of every ``# - `` line is enforced globally by the
+    shared convention test (tests/shared/test_template_conventions.py).
+    """
+
+    def test_load_template_header_documents_known_options(self):
+        path = (
+            MODULE_RESOURCES["dagster"]
+            / "templates" / "dags" / "load" / "dagster__scheduled_table__shell.py.j2"
+        )
+        options = parse_header_options(path)
+        expected = {
+            "sl_env_var", "SL_STARLAKE_PATH", "pre_load_strategy",
+            "retries", "retry_delay",
+        }
+        missing = expected - set(options)
+        assert not missing, f"Load template header no longer documents: {missing}"
+
+    def test_transform_template_header_documents_known_options(self):
+        path = (
+            MODULE_RESOURCES["dagster"]
+            / "templates" / "dags" / "transform" / "dagster__scheduled_task__shell.py.j2"
+        )
+        options = parse_header_options(path)
+        expected = {
+            "sl_env_var", "SL_STARLAKE_PATH", "run_dependencies_first",
+            "retries", "retry_delay",
+        }
+        missing = expected - set(options)
+        assert not missing, f"Transform template header no longer documents: {missing}"

--- a/tests/shared/template_test_utils.py
+++ b/tests/shared/template_test_utils.py
@@ -1,0 +1,263 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Shared utilities for Jinja2 template tests across the four modules.
+
+Plain importable module (like ``set_env``/``get_duckdb`` in
+``tests/shared/conftest.py``) — deliberately NOT fixtures, so both the
+per-orchestrator template tests and the shared convention scan can use
+them without conftest plumbing.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from jinja2 import Environment, FileSystemLoader
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+MODULE_RESOURCES: Dict[str, Path] = {
+    "airflow": PROJECT_ROOT / "starlake-airflow" / "src" / "main" / "resources",
+    "dagster": PROJECT_ROOT / "starlake-dagster" / "src" / "main" / "resources",
+    "snowflake": PROJECT_ROOT / "starlake-snowflake" / "src" / "main" / "resources",
+    "orchestration": PROJECT_ROOT / "starlake-orchestration" / "src" / "main" / "resources",
+}
+
+# Orchestrator prefix (template filename) -> snippet include path
+ORCHESTRATOR_SNIPPETS: Dict[str, str] = {
+    "airflow": "templates/dags/__starlake_airflow_orchestrator.py.j2",
+    "dagster": "templates/dags/__starlake_dagster_orchestrator.py.j2",
+    "snowflake": "templates/dags/__starlake_snowflake_orchestrator.py.j2",
+    "starlake": "templates/dags/__starlake_sl_orchestrator.py.j2",
+}
+
+# Orchestrator prefix -> StarlakeOrchestrator enum member set by the snippet.
+# NOTE: the enum also defines COMPOSER = "airflow" (a value-alias of AIRFLOW
+# that no snippet sets) — expectations are pinned here, never derived by
+# iterating the enum.
+ORCHESTRATOR_ENUMS: Dict[str, str] = {
+    "airflow": "AIRFLOW",
+    "dagster": "DAGSTER",
+    "snowflake": "SNOWFLAKE",
+    "starlake": "STARLAKE",
+}
+
+TEMPLATE_NAME_RE = re.compile(
+    r"^(airflow|dagster|snowflake|starlake)__scheduled_(table|task)__[a-z0-9_]+\.py\.j2$"
+)
+
+# Header option line, e.g.:
+# "# - ack_wait_timeout(3600): when ... the timeout in seconds [OPTIONAL]"
+# "# - warehouse(COMPUTE_WH): the warehouse to use for the DAG [OPTIONAL], default to COMPUTE_WH"
+#
+# MUST mirror the Starlake CLI's own header parser — DagTemplateOption.fromLine
+# (starlake/src/main/scala/ai/starlake/utils/AnyTemplateLoader.scala:39-62):
+#  - line starts with "# - ";
+#  - split(':') must yield EXACTLY 2 parts, i.e. exactly one ':' on the line
+#    (a colon in the description makes the option INVISIBLE to the CLI);
+#  - tag detected via contains("[OPTIONAL]"/"[REQUIRED]") — trailing text after
+#    the tag is legal (the snowflake headers use ", default to ...").
+# Verified 2026-07-14: every `# - ` line in all 20 user-facing templates
+# matches this regex (exactly one colon, tag present).
+HEADER_OPTION_RE = re.compile(
+    r"^# - (?P<name>[A-Za-z_][A-Za-z0-9_]*)"
+    r"(\((?P<default>[^)]*)\))?"
+    r"\s*:[^:]*\[(?P<tag>OPTIONAL|REQUIRED)\][^:]*$"
+)
+
+
+def make_jinja_env(module: str) -> Environment:
+    """Jinja2 environment for *module*, with the core module as fallback root.
+
+    Mirrors what the Starlake CLI does: templates include files from both the
+    orchestrator jar and the starlake-orchestration jar.
+    """
+    roots = [str(MODULE_RESOURCES[module])]
+    if module != "orchestration":
+        roots.append(str(MODULE_RESOURCES["orchestration"]))
+    return Environment(loader=FileSystemLoader(roots), keep_trailing_newline=True)
+
+
+class _Option:
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+
+class _Table:
+    def __init__(self, name):
+        self.name = name
+        self.final_name = name
+
+
+class _Domain:
+    def __init__(self, name, tables):
+        self.name = name
+        self.final_name = name
+        self.tables = [_Table(t) for t in tables]
+
+
+class _Schedule:
+    def __init__(self, schedule, cron, domains):
+        self.schedule = schedule
+        self.cron = cron
+        self.domains = [_Domain(d, tables) for d, tables in domains.items()]
+
+
+class _Config:
+    def __init__(self, comment, template, options):
+        self.comment = comment
+        self.template = template
+        self.options = options
+
+
+_DEFAULT_OPTIONS = {
+    "airflow": [
+        _Option("SL_ROOT", "/tmp/test"),
+        _Option("SL_ENV", "DUCKDB"),
+        _Option("SL_STARLAKE_PATH", "starlake"),
+        _Option("pre_load_strategy", "imported"),
+        _Option("tags", "starbake"),
+    ],
+    "dagster": [
+        _Option("SL_ROOT", "/tmp/test"),
+        _Option("SL_ENV", "DUCKDB"),
+        _Option("SL_STARLAKE_PATH", "starlake"),
+        _Option("pre_load_strategy", "imported"),
+        _Option("tags", "starbake"),
+    ],
+    "snowflake": [
+        _Option("SL_ROOT", "/tmp/test"),
+        _Option("SL_ENV", "DUCKDB"),
+        _Option("stage_location", "staging"),
+        _Option("warehouse", "COMPUTE_WH"),
+        _Option("timezone", "UTC"),
+    ],
+}
+
+
+class _Context:
+    def __init__(self, orchestrator, template, comment):
+        # .get with airflow fallback: "starlake"-prefixed templates have no
+        # dedicated option set (no render-chain tests for them in this story).
+        self.config = _Config(
+            comment,
+            template,
+            list(_DEFAULT_OPTIONS.get(orchestrator, _DEFAULT_OPTIONS["airflow"])),
+        )
+        self.cron = "0 0 * * *"
+        self.schedules = [
+            _Schedule(
+                schedule="daily",
+                cron="0 0 * * *",
+                domains={"starbake": ["customers", "orders", "products"]},
+            ),
+        ]
+        self.dependencies = "[]"
+        # Airflow snippet reads this (context.sl_airflow_access_control);
+        # harmless superset for the other orchestrators.
+        self.sl_airflow_access_control = "None"
+        # Snowflake SQL execution snippet reads these; harmless superset.
+        self.statements = "{}"
+        self.expectationItems = "{}"
+        self.audit = "{}"
+        self.expectations = "{}"
+        self.acl = "{}"
+
+
+def make_mock_context(
+    orchestrator: str,
+    template: Optional[str] = None,
+    comment: str = "Test DAG for loading starbake tables",
+) -> object:
+    """Superset mock of the context ``starlake dag-generate`` provides."""
+    if template is None:
+        template = f"load/{orchestrator}__scheduled_table__shell.py.j2"
+    return _Context(orchestrator, template, comment)
+
+
+def user_facing_templates() -> List[Path]:
+    """All non-underscore *.py.j2 DAG templates across the four modules.
+
+    "User-facing" per the Starlake CLI's own filter
+    (``AnyTemplateLoader``: ``!name.startsWith("_") && name.endsWith(".j2")``):
+    underscore-prefixed files are snippets.
+    """
+    files = []
+    for resources in MODULE_RESOURCES.values():
+        for sub in ("load", "transform"):
+            folder = resources / "templates" / "dags" / sub
+            if folder.is_dir():
+                files.extend(
+                    p for p in sorted(folder.glob("*.py.j2"))
+                    if not p.name.startswith("_")
+                )
+    # Zero-scan guard (feedback_test_assertion_quality): 20 verified 2026-07-14
+    # (airflow 8, dagster 8, snowflake 2, orchestration 2).
+    assert len(files) >= 20, f"Expected >= 20 user-facing templates, found {len(files)}"
+    return files
+
+
+def parse_header_options(template_path: Path) -> Dict[str, str]:
+    """Parse the leading comment block of a template into {option: tag}.
+
+    Returns an empty dict if the file does not start with a header block.
+    """
+    options = {}
+    for line in template_path.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("#"):
+            break  # header block ends at the first non-comment line
+        m = HEADER_OPTION_RE.match(line)
+        if m:
+            options[m.group("name")] = m.group("tag")
+    return options
+
+
+def assert_dag_generate_idempotent(runtime_dags, tmp_path_factory) -> None:
+    """NFR2 at the CLI layer: a second dag-generate run is byte-identical.
+
+    ``runtime_dags`` is the shared module-scoped fixture (tests/shared/conftest.py)
+    that already ran dag-generate once; re-run with the SAME env into a fresh dir.
+    """
+    first_out, _isolated, env = runtime_dags
+    # runtime_env prepended the CLI dir to env["PATH"]; subprocess resolves
+    # the program via os.get_exec_path(env), so plain "starlake" hits the
+    # same binary runtime_dags used.
+    second_out = tmp_path_factory.mktemp("runtime_dags_rerun")
+    result = subprocess.run(
+        ["starlake", "dag-generate", "--outputDir", str(second_out)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"second dag-generate failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    first_files = sorted(p.name for p in first_out.glob("*.py"))
+    second_files = sorted(p.name for p in second_out.glob("*.py"))
+    assert first_files == second_files, (
+        f"File sets differ: {first_files} vs {second_files}"
+    )
+    assert len(first_files) > 0, "dag-generate produced no files"
+    for name in first_files:
+        a = (first_out / name).read_bytes()
+        b = (second_out / name).read_bytes()
+        assert a == b, f"{name} is not byte-identical across dag-generate runs (NFR2)"

--- a/tests/shared/test_template_conventions.py
+++ b/tests/shared/test_template_conventions.py
@@ -1,0 +1,135 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Cross-orchestrator template convention scan (AC1, AC4).
+
+Runs on the ``orchestration`` CI leg — no orchestrator package imports
+anywhere in this file; only ``jinja2``/``pytest`` from the test extra.
+Any core-module change triggers this leg (and fans out to all legs), so
+cross-module conventions re-run whenever the core changes or on
+``workflow_dispatch``; single-module template edits are gated by that
+module's own ``test_{orch}_templates.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from tests.shared.template_test_utils import (
+    HEADER_OPTION_RE,
+    MODULE_RESOURCES,
+    ORCHESTRATOR_ENUMS,
+    ORCHESTRATOR_SNIPPETS,
+    TEMPLATE_NAME_RE,
+    parse_header_options,
+    user_facing_templates,
+)
+
+# {% include 'path' %} or {% include "path" %}
+_INCLUDE_RE = re.compile(r"""{%\s*include\s+['"](?P<path>[^'"]+)['"]\s*%}""")
+
+
+def _includes(template_path):
+    return [m.group("path") for m in _INCLUDE_RE.finditer(
+        template_path.read_text(encoding="utf-8")
+    )]
+
+
+class TestTemplateNamingConvention:
+
+    def test_every_user_facing_template_matches_naming_convention(self):
+        offenders = [
+            p.name for p in user_facing_templates()
+            if not TEMPLATE_NAME_RE.match(p.name)
+        ]
+        assert not offenders, (
+            f"Templates violating {{orchestrator}}__scheduled_{{type}}__{{env}}.py.j2: "
+            f"{offenders}"
+        )
+
+
+class TestTemplateHeaderConvention:
+
+    def test_every_user_facing_template_has_documented_header(self):
+        undocumented = []
+        for path in user_facing_templates():
+            options = parse_header_options(path)
+            if not options:
+                undocumented.append(path.name)
+        assert not undocumented, (
+            f"Templates missing a '# - option: description [OPTIONAL|REQUIRED]' "
+            f"header block: {undocumented}"
+        )
+
+    def test_header_block_precedes_first_include(self):
+        offenders = []
+        for path in user_facing_templates():
+            text = path.read_text(encoding="utf-8")
+            first_include = text.find("{%")
+            first_option = text.find("# - ")
+            if first_option == -1 or (first_include != -1 and first_option > first_include):
+                offenders.append(path.name)
+        assert not offenders, f"Header block must precede includes in: {offenders}"
+
+    def test_every_header_option_line_is_cli_parseable(self):
+        """Every `# - ` line must parse exactly as the Starlake CLI parses it.
+
+        DagTemplateOption.fromLine (AnyTemplateLoader.scala:39-62) silently
+        DROPS any `# - ` line whose split(':') is not exactly 2 parts or that
+        lacks an [OPTIONAL]/[REQUIRED] tag — an unparseable line is an option
+        invisible to `starlake dag-templates` and to the Epic 4 AI skills.
+        """
+        offenders = []
+        for path in user_facing_templates():
+            for line in path.read_text(encoding="utf-8").splitlines():
+                if not line.startswith("#"):
+                    break  # header block ends at the first non-comment line
+                if line.startswith("# - ") and not HEADER_OPTION_RE.match(line):
+                    offenders.append((path.name, line))
+        assert not offenders, (
+            f"Header option lines the Starlake CLI cannot parse: {offenders}"
+        )
+
+
+class TestSnippetComposition:
+
+    def test_every_template_includes_its_orchestrator_snippet(self):
+        offenders = []
+        for path in user_facing_templates():
+            prefix = path.name.split("__", 1)[0]
+            snippet = ORCHESTRATOR_SNIPPETS.get(prefix)
+            if snippet is None:
+                # Unknown prefix — the naming-convention test reports it too;
+                # list it here instead of raising KeyError mid-scan.
+                offenders.append((path.name, f"unknown orchestrator prefix '{prefix}'"))
+                continue
+            if snippet not in _includes(path):
+                offenders.append((path.name, snippet))
+        assert not offenders, f"Templates missing their orchestrator snippet: {offenders}"
+
+    @pytest.mark.parametrize("prefix", sorted(ORCHESTRATOR_SNIPPETS))
+    def test_snippet_includes_common_and_sets_enum(self, prefix):
+        snippet_rel = ORCHESTRATOR_SNIPPETS[prefix]
+        module = "orchestration" if prefix == "starlake" else prefix
+        snippet_path = MODULE_RESOURCES[module] / snippet_rel
+        assert snippet_path.is_file(), f"Missing snippet: {snippet_path}"
+        text = snippet_path.read_text(encoding="utf-8")
+        assert "templates/dags/__common__.py.j2" in text
+        assert (
+            f"orchestrator = StarlakeOrchestrator.{ORCHESTRATOR_ENUMS[prefix]}" in text
+        )

--- a/tests/snowflake/conftest.py
+++ b/tests/snowflake/conftest.py
@@ -282,3 +282,60 @@ def runtime_config():
         "transform_dag_ref": "snowflake_transform_sql",
         "dag_config_glob": "snowflake_*.sl.yml",
     }
+
+
+# ---------------------------------------------------------------------------
+# Runtime pipeline fixtures — shared by test_snowflake_runtime.py and
+# test_snowflake_parser_validation.py (moved here from
+# test_snowflake_runtime.py, story 3.2 — behavior-neutral: pytest resolves
+# them from the package conftest; each consuming module still gets its own
+# module-scoped instances).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def generated_python_files(runtime_dags):
+    """Return all generated ``*.py`` DAG files from ``runtime_dags``."""
+    dags_dir, _, _ = runtime_dags
+    files = sorted(dags_dir.glob("*.py"))
+    assert len(files) > 0, f"No .py files in {dags_dir}"
+    return files
+
+
+@pytest.fixture(scope="module")
+def runtime_mock_session():
+    """Module-scoped mock Snowpark Session (named to avoid shadowing conftest)."""
+    session = MagicMock()
+    session.sql.return_value.collect.return_value = []
+    session.call.return_value = None
+    return session
+
+
+# MERGE NOTE (story 3.1 / PR #66 coordination): PR #66 promotes an identical
+# ``runtime_env_vars`` fixture to tests/shared/conftest.py. Once #66 is
+# merged, DELETE this copy — a package-conftest copy would SHADOW the shared
+# one. It lives here (not in a test module) because ``loaded_pipelines``
+# below must resolve it from conftest scope on this branch.
+@pytest.fixture(scope="module")
+def runtime_env_vars(runtime_dags):
+    """Set runtime env vars for the module and restore on teardown."""
+    from tests.shared.conftest import restore_env, set_env
+
+    _, _, env = runtime_dags
+    original = set_env(env)
+    yield env
+    restore_env(original)
+
+
+@pytest.fixture(scope="module")
+def loaded_pipelines(generated_python_files, runtime_env_vars, runtime_mock_session):
+    """Load all pipelines from generated DAG files."""
+    from ai.starlake.orchestration.__main__ import load_pipelines
+
+    all_pipelines = []
+    for py_file in generated_python_files:
+        pipelines = load_pipelines(str(py_file))
+        if pipelines:
+            all_pipelines.extend(pipelines)
+    assert len(all_pipelines) > 0, "No pipelines loaded from generated files"
+    return all_pipelines

--- a/tests/snowflake/test_snowflake_parser_validation.py
+++ b/tests/snowflake/test_snowflake_parser_validation.py
@@ -1,0 +1,88 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""AC3 / NFR8 — Snowflake task validation of generated DAGs.
+
+Full chain: ``starlake dag-generate`` (shared ``runtime_dags`` fixture)
+→ generated ``.py`` files → ``load_pipelines()`` → built
+``snowflake.core.task.dag.DAG`` object graph with ``StoredProcedureCall``
+definitions. DAG construction happens in the pipeline's ``__exit__`` with
+no live Session (the mocked-lifecycle boundary established in Epic 1) —
+no new mocking required.
+
+Fixtures (``generated_python_files``, ``runtime_mock_session``,
+``runtime_env_vars``, ``loaded_pipelines``) live in
+``tests/snowflake/conftest.py`` — shared with ``test_snowflake_runtime.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.shared.template_test_utils import assert_dag_generate_idempotent
+
+# Mark all tests — they require Starlake CLI + Java runtime.
+pytestmark = [
+    pytest.mark.integration,
+]
+
+
+class TestSnowflakeTaskValidation:
+    """AC3 / NFR8 — Snowflake task validation of generated DAGs."""
+
+    def test_pipelines_build_snowflake_dags(self, loaded_pipelines):
+        for p in loaded_pipelines:
+            assert p.dag is not None
+            assert p.dag.name == p.pipeline_id
+
+    def test_dag_root_definition_is_stored_procedure_call(self, loaded_pipelines):
+        from snowflake.core.task import StoredProcedureCall
+
+        for p in loaded_pipelines:
+            assert isinstance(p.dag.definition, StoredProcedureCall)
+
+    def test_every_task_has_definition_and_unique_name(self, loaded_pipelines):
+        for p in loaded_pipelines:
+            names = [t.name for t in p.dag.tasks]
+            assert len(names) == len(set(names)), (
+                f"Duplicate task names in {p.pipeline_id}: {names}"
+            )
+            for task in p.dag.tasks:
+                assert task.definition is not None, (
+                    f"Task {task.name} in {p.pipeline_id} has no definition"
+                )
+
+
+class TestSnowflakeDagGenerateIdempotence:
+    """AC2 / NFR2 — dag-generate output is byte-identical across runs.
+
+    KNOWN VIOLATION (issue #70): the CLI's Snowflake statement compilation
+    embeds generation-time values in every generated file — timestamped
+    audit task names (``audit.audit-<table>-<epoch millis>``, load AND
+    transform) and a random ``tempStage`` suffix (load). The byte-identity
+    oracle is NOT weakened (no normalization): the test is pinned
+    xfail(strict=True) so a CLI fix surfaces as XPASS and forces removal
+    of the marker. Airflow/Dagster equivalents pass strictly.
+    """
+
+    @pytest.mark.xfail(
+        raises=AssertionError,
+        strict=True,
+        reason="starlake-ai/starlake-orchestration#70 — snowflake dag-generate "
+        "embeds timestamped audit names and random tempStage suffixes (NFR2)",
+    )
+    def test_dag_generate_is_idempotent(self, runtime_dags, tmp_path_factory):
+        assert_dag_generate_idempotent(runtime_dags, tmp_path_factory)

--- a/tests/snowflake/test_snowflake_runtime.py
+++ b/tests/snowflake/test_snowflake_runtime.py
@@ -16,13 +16,9 @@
 
 from __future__ import annotations
 
-import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
-
-from ai.starlake.orchestration import AbstractPipeline
-from tests.shared.conftest import set_env, restore_env
 
 
 # Mark all tests — they require Starlake CLI + Java runtime.
@@ -30,46 +26,10 @@ pytestmark = [
     pytest.mark.integration,
 ]
 
-
-@pytest.fixture(scope="module")
-def generated_python_files(runtime_dags):
-    """Return all generated ``*.py`` DAG files from ``runtime_dags``."""
-    dags_dir, _, _ = runtime_dags
-    files = sorted(dags_dir.glob("*.py"))
-    assert len(files) > 0, f"No .py files in {dags_dir}"
-    return files
-
-
-@pytest.fixture(scope="module")
-def runtime_mock_session():
-    """Module-scoped mock Snowpark Session (named to avoid shadowing conftest)."""
-    session = MagicMock()
-    session.sql.return_value.collect.return_value = []
-    session.call.return_value = None
-    return session
-
-
-@pytest.fixture(scope="module")
-def runtime_env_vars(runtime_dags):
-    """Set runtime env vars for the module and restore on teardown."""
-    _, _, env = runtime_dags
-    original = set_env(env)
-    yield env
-    restore_env(original)
-
-
-@pytest.fixture(scope="module")
-def loaded_pipelines(generated_python_files, runtime_env_vars, runtime_mock_session):
-    """Load all pipelines from generated DAG files."""
-    from ai.starlake.orchestration.__main__ import load_pipelines
-
-    all_pipelines = []
-    for py_file in generated_python_files:
-        pipelines = load_pipelines(str(py_file))
-        if pipelines:
-            all_pipelines.extend(pipelines)
-    assert len(all_pipelines) > 0, "No pipelines loaded from generated files"
-    return all_pipelines
+# The module-scoped runtime fixtures (``generated_python_files``,
+# ``runtime_mock_session``, ``runtime_env_vars``, ``loaded_pipelines``)
+# moved to tests/snowflake/conftest.py (story 3.2) — they are shared with
+# test_snowflake_parser_validation.py.
 
 
 # ------------------------------------------------------------------

--- a/tests/snowflake/test_snowflake_templates.py
+++ b/tests/snowflake/test_snowflake_templates.py
@@ -17,21 +17,15 @@
 from __future__ import annotations
 
 import ast
-from pathlib import Path
 
 import pytest
-from jinja2 import Environment, FileSystemLoader, TemplateSyntaxError
+from jinja2 import TemplateSyntaxError
 
-# ---------------------------------------------------------------------------
-# Template search paths — templates include files from multiple modules
-# ---------------------------------------------------------------------------
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[2]
-_SNOWFLAKE_RESOURCES = (
-    _PROJECT_ROOT / "starlake-snowflake" / "src" / "main" / "resources"
-)
-_ORCH_RESOURCES = (
-    _PROJECT_ROOT / "starlake-orchestration" / "src" / "main" / "resources"
+from tests.shared.template_test_utils import (
+    MODULE_RESOURCES,
+    make_jinja_env,
+    make_mock_context,
+    parse_header_options,
 )
 
 _SQL_LOAD_TEMPLATE = "templates/dags/load/snowflake__scheduled_table__sql.py.j2"
@@ -40,78 +34,10 @@ _SQL_TRANSFORM_TEMPLATE = (
 )
 
 
-def _make_mock_context():
-    """Build a minimal mock context matching what ``starlake dag-generate`` provides.
-
-    Snowflake SQL templates require additional context fields beyond Dagster:
-    ``statements``, ``expectationItems``, ``audit``, ``expectations``,
-    ``acl``, and ``pyjson`` (load only).
-    """
-
-    class _Option:
-        def __init__(self, name, value):
-            self.name = name
-            self.value = value
-
-    class _Table:
-        def __init__(self, name):
-            self.name = name
-            self.final_name = name
-
-    class _Domain:
-        def __init__(self, name, tables):
-            self.name = name
-            self.final_name = name
-            self.tables = [_Table(t) for t in tables]
-
-    class _Schedule:
-        def __init__(self, schedule, cron, domains):
-            self.schedule = schedule
-            self.cron = cron
-            self.domains = [_Domain(d, tables) for d, tables in domains.items()]
-
-    class _Config:
-        def __init__(self):
-            self.comment = "Test DAG for loading starbake tables"
-            self.template = "load/snowflake__scheduled_table__sql.py.j2"
-            self.options = [
-                _Option("SL_ROOT", "/tmp/test"),
-                _Option("SL_ENV", "DUCKDB"),
-                _Option("stage_location", "staging"),
-                _Option("warehouse", "COMPUTE_WH"),
-                _Option("timezone", "UTC"),
-            ]
-
-    class _Context:
-        def __init__(self):
-            self.config = _Config()
-            self.cron = "0 0 * * *"
-            self.schedules = [
-                _Schedule(
-                    schedule="daily",
-                    cron="0 0 * * *",
-                    domains={"starbake": ["customers", "orders"]},
-                ),
-            ]
-            self.dependencies = "[]"
-            self.statements = "{}"
-            self.expectationItems = "{}"
-            self.audit = "{}"
-            self.expectations = "{}"
-            self.acl = "{}"
-
-    return _Context()
-
-
 @pytest.fixture(scope="module")
 def jinja_env():
     """Jinja2 environment with search paths covering Snowflake and core modules."""
-    return Environment(
-        loader=FileSystemLoader(
-            [str(_SNOWFLAKE_RESOURCES), str(_ORCH_RESOURCES)]
-        ),
-        keep_trailing_newline=True,
-    )
+    return make_jinja_env("snowflake")
 
 
 # ------------------------------------------------------------------
@@ -141,7 +67,11 @@ class TestSnowflakeTemplates:
     def test_load_template_renders_valid_python(self, jinja_env):
         """Render load template with mock variables and verify valid Python."""
         template = jinja_env.get_template(_SQL_LOAD_TEMPLATE)
-        rendered = template.render(context=_make_mock_context(), pyjson="{}")
+        context = make_mock_context(
+            "snowflake",
+            template="load/snowflake__scheduled_table__sql.py.j2",
+        )
+        rendered = template.render(context=context, pyjson="{}")
         try:
             ast.parse(rendered)
         except SyntaxError as exc:
@@ -152,10 +82,10 @@ class TestSnowflakeTemplates:
 
     def test_transform_template_renders_valid_python(self, jinja_env):
         """Render transform template with mock variables and verify valid Python."""
-        context = _make_mock_context()
-        context.config.comment = "Test DAG for transforming starbake tasks"
-        context.config.template = (
-            "transform/snowflake__scheduled_task__sql.py.j2"
+        context = make_mock_context(
+            "snowflake",
+            template="transform/snowflake__scheduled_task__sql.py.j2",
+            comment="Test DAG for transforming starbake tasks",
         )
         template = jinja_env.get_template(_SQL_TRANSFORM_TEMPLATE)
         rendered = template.render(context=context)
@@ -166,3 +96,134 @@ class TestSnowflakeTemplates:
                 f"Rendered transform template is not valid Python: {exc}\n"
                 f"--- rendered output ---\n{rendered[:500]}"
             )
+
+
+# ------------------------------------------------------------------
+# Story 3.2 — AC1 snippet composition
+# ------------------------------------------------------------------
+
+class TestSnowflakeTemplateComposition:
+    """AC1 — snippet composition is visible in the rendered output.
+
+    The Snowflake snippet sets ONLY the orchestrator enum (verified) —
+    the negative assertions pin that snippet contract.
+
+    NOTE: the snowflake load template includes ``__common__.py.j2`` a
+    SECOND time directly (line 15, besides the include inside the
+    orchestrator snippet) — rendered load output contains ``description=``
+    /``template=``/``options={...}`` TWICE (later assignment wins; benign).
+    Assertions therefore stay substring-based — never single-occurrence.
+    """
+
+    def test_load_template_composes_orchestrator_snippet(self, jinja_env):
+        context = make_mock_context(
+            "snowflake",
+            template="load/snowflake__scheduled_table__sql.py.j2",
+        )
+        rendered = jinja_env.get_template(_SQL_LOAD_TEMPLATE).render(
+            context=context, pyjson="{}"
+        )
+        # __starlake_snowflake_orchestrator.py.j2 — enum ONLY
+        assert "orchestrator = StarlakeOrchestrator.SNOWFLAKE" in rendered
+        assert "access_control" not in rendered
+        assert "default_dag_args" not in rendered
+        # __starlake_sql_execution.py.j2 — SQL execution environment
+        assert "execution_environment = StarlakeExecutionEnvironment.SQL" in rendered
+        assert "statements = {}" in rendered
+        assert "expectation_items = {}" in rendered
+        assert "audit = {}" in rendered
+        assert "expectations = {}" in rendered
+        assert "acl = {}" in rendered
+        # top-level pyjson render var (load only)
+        assert "json_context = '''{}'''" in rendered
+        # __common__.py.j2 — config projection
+        assert 'description="""Test DAG for loading starbake tables"""' in rendered
+        assert 'template="load/snowflake__scheduled_table__sql.py.j2"' in rendered
+        assert "'stage_location':'staging'" in rendered
+        # inlined pipeline body (the snowflake load template does NOT use
+        # load/__scheduled_table_tpl.py.j2 but carries its own copy)
+        assert (
+            "with OrchestrationFactory.create_orchestration(job=sl_job) as orchestration:"
+            in rendered
+        )
+
+    def test_transform_template_composes_orchestrator_snippet(self, jinja_env):
+        context = make_mock_context(
+            "snowflake",
+            template="transform/snowflake__scheduled_task__sql.py.j2",
+            comment="Test DAG for transforming starbake tasks",
+        )
+        rendered = jinja_env.get_template(_SQL_TRANSFORM_TEMPLATE).render(context=context)
+        assert "orchestrator = StarlakeOrchestrator.SNOWFLAKE" in rendered
+        assert "execution_environment = StarlakeExecutionEnvironment.SQL" in rendered
+        assert "statements = {}" in rendered
+        assert "acl = {}" in rendered
+        # transform uses the shared task template — no pyjson/json_context
+        assert "json_context" not in rendered
+        # transform/__scheduled_task_tpl.py.j2 — dependency-driven pipeline logic
+        assert 'cron = "0 0 * * *"' in rendered
+        assert 'dependencies=StarlakeDependencies(dependencies="""[]"""' in rendered
+
+
+# ------------------------------------------------------------------
+# Story 3.2 — AC2 / NFR2 render idempotence
+# ------------------------------------------------------------------
+
+class TestSnowflakeTemplateIdempotence:
+    """AC2 / NFR2 — byte-identical re-render at the Python-Jinja2 layer."""
+
+    def _render(self, env, template_name):
+        kwargs = {"context": make_mock_context("snowflake", template=template_name)}
+        if template_name == _SQL_LOAD_TEMPLATE:
+            kwargs["pyjson"] = "{}"
+        return env.get_template(template_name).render(**kwargs)
+
+    @pytest.mark.parametrize(
+        "template_name", [_SQL_LOAD_TEMPLATE, _SQL_TRANSFORM_TEMPLATE]
+    )
+    def test_render_is_byte_identical(self, jinja_env, template_name):
+        first = self._render(jinja_env, template_name)
+        second = self._render(jinja_env, template_name)
+        # And from a completely fresh Environment (no loader/cache state):
+        third = self._render(make_jinja_env("snowflake"), template_name)
+        assert first == second
+        assert first.encode("utf-8") == third.encode("utf-8"), (
+            f"{template_name} render is not idempotent across environments (NFR2)"
+        )
+
+
+# ------------------------------------------------------------------
+# Story 3.2 — AC4 self-documenting headers
+# ------------------------------------------------------------------
+
+class TestSnowflakeTemplateHeaderOptions:
+    """AC4 — header comments document the options (existing convention).
+
+    CLI-parseability of every ``# - `` line is enforced globally by the
+    shared convention test (tests/shared/test_template_conventions.py).
+    """
+
+    def test_load_template_header_documents_known_options(self):
+        path = (
+            MODULE_RESOURCES["snowflake"]
+            / "templates" / "dags" / "load" / "snowflake__scheduled_table__sql.py.j2"
+        )
+        options = parse_header_options(path)
+        expected = {
+            "stage_location", "sl_incoming_file_stage", "warehouse",
+            "timezone", "packages", "sl_env_var",
+        }
+        missing = expected - set(options)
+        assert not missing, f"Load template header no longer documents: {missing}"
+
+    def test_transform_template_header_documents_known_options(self):
+        path = (
+            MODULE_RESOURCES["snowflake"]
+            / "templates" / "dags" / "transform" / "snowflake__scheduled_task__sql.py.j2"
+        )
+        options = parse_header_options(path)
+        expected = {
+            "stage_location", "warehouse", "timezone", "packages", "sl_env_var",
+        }
+        missing = expected - set(options)
+        assert not missing, f"Transform template header no longer documents: {missing}"


### PR DESCRIPTION
## Summary

Tests-only story: proves each orchestrator's Jinja2 templates correctly compose orchestrator snippets with shared template code, render idempotently, produce parser-valid DAGs, and stay self-documenting via CLI-parseable header options.

- **Shared utils** (`tests/shared/template_test_utils.py`): module resource map, snippet/enum contract, single `make_mock_context` (dedupes 3 per-module copies), CLI-aligned `parse_header_options` (mirrors `DagTemplateOption.fromLine`: one colon, `[OPTIONAL]`/`[REQUIRED]` tag, trailing text legal), `user_facing_templates` (>=20 zero-scan guard), `assert_dag_generate_idempotent`.
- **Cross-module convention scan** (`tests/shared/test_template_conventions.py`, orchestration CI leg): naming `{orch}__scheduled_{table|task}__{env}.py.j2`, header block present/CLI-parseable/precedes includes, every template includes its orchestrator snippet, every snippet includes `__common__.py.j2` + sets the matching `StarlakeOrchestrator` member.
- **Per-orchestrator template tests**: composition + byte-identical re-render (NFR2, jinja2 layer) + known-minimum header sets; negative assertions pin the snippet contract (only Airflow sets `access_control`/`default_dag_args`). Existing 4 test names per module kept.
- **Parser validation (NFR8)**: full `dag-generate` → parser chain — Airflow `DagBag` zero import errors on BOTH 2.10.5 and 3.3.0 (un-skipped; `airflow.dag_processing.dagbag` on 3.x), Dagster `Definitions.validate_loadable` + pipeline jobs (implicit `__ASSET_JOB` filtered), Snowflake `StoredProcedureCall` DAG structure; plus per-leg dag-generate byte-idempotence (~10 s extra per leg, warm JVM).

## Findings (issue-first)

- **#70 — REAL NFR2 violation (snowflake only)**: dag-generate output embeds timestamped audit task names (load+transform) and a random `tempStage` suffix (load) → not byte-identical across runs. Pinned `xfail(strict=True, raises=AssertionError)`; airflow/dagster byte-idempotence passes strictly (oracle unweakened). A CLI fix will XPASS and force marker removal.
- **#72 — snowflake load template double-includes `__common__.py.j2`** (confirmed in real dag-generate output; benign, documentation only — no template edit in this tests-only PR).

## MERGE NOTE (coordination with PR #66)

PR #66 (story 3.1) promotes `runtime_env_vars` to `tests/shared/conftest.py` and deletes the two snowflake local copies. This branch (off main, without #66) moves the snowflake runtime fixtures — including `runtime_env_vars` — to `tests/snowflake/conftest.py` (the new parser module resolves `loaded_pipelines` from conftest scope). **After #66 merges, DELETE the `runtime_env_vars` copy from `tests/snowflake/conftest.py`** (a package-conftest copy shadows the shared fixture); an explicit MERGE NOTE comment marks the spot. The `test_snowflake_runtime.py` deletions overlap #66's own deletions (compatible).

Sibling PRs: #66 (story 3.1), #68 (story 3.3).

## Test results (fresh non-editable venvs from branch source)

| Leg | Result |
| --- | --- |
| orchestration + shared (py3.11) | 123 passed |
| airflow 2.10.5 (py3.11, constraints) | 134 passed |
| airflow 3.3.0 (py3.11, constraints) | 125 passed, 9 pre-existing skips |
| dagster 1.9.13 | 95 passed |
| snowflake | 70 passed, 8 xfailed (7 pre-existing + #70 pin) |

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)