### PR TITLE
Story 3.6 — Cross-orchestrator database connection portability

### DIFF
--- a/tests/airflow/test_airflow_connection_agnosticism.py
+++ b/tests/airflow/test_airflow_connection_agnosticism.py
@@ -1,0 +1,46 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.shared.connection_audit import find_connection_logic_violations
+
+_MODULE_SRC = (
+    Path(__file__).resolve().parents[2]
+    / "starlake-airflow" / "src" / "main" / "python" / "ai" / "starlake"
+)
+
+
+class TestAirflowConnectionAgnosticism:
+    """AC #4: no database-specific logic in the Airflow module.
+
+    Legitimate DB-flavoured vocabulary deliberately NOT flagged:
+    ``spark.datasource.bigquery.*`` Spark properties (Dataproc
+    execution-environment tuning) and ``sqlalchemy`` imports targeting
+    Airflow's own metadata DB — neither is warehouse connection config.
+    """
+
+    def test_no_database_specific_logic(self):
+        assert _MODULE_SRC.is_dir(), f"Module source not found at {_MODULE_SRC}"
+        py_files, violations = find_connection_logic_violations(_MODULE_SRC)
+        # Sentinel guard: the scan must have covered the real module,
+        # not an empty directory (see feedback_test_assertion_quality).
+        assert any(p.name == "starlake_airflow_job.py" for p in py_files), (
+            f"Scan missed the module entry point; scanned: {py_files}"
+        )
+        assert violations == [], "\n".join(violations)

--- a/tests/airflow/test_airflow_connection_portability.py
+++ b/tests/airflow/test_airflow_connection_portability.py
@@ -1,0 +1,45 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import pytest
+
+from tests.airflow.airflow_test_mixin import AirflowTestMixin
+from tests.shared.base_test_connection_portability import (
+    BACKEND_ENVS,
+    BaseTestConnectionPortability,
+)
+
+
+class TestAirflowConnectionPortability(AirflowTestMixin, BaseTestConnectionPortability):
+    """Airflow pass-through: inherited base tests + operator env checks."""
+
+    @pytest.mark.parametrize("backend", sorted(BACKEND_ENVS))
+    def test_operator_env_contains_backend_vars(self, backend):
+        """The BashOperator env dict carries every backend var verbatim.
+
+        Airflow's SubprocessHook REPLACES os.environ with task.env when
+        env is non-empty — so task.env IS the exact environment the
+        Starlake CLI would see.  task.env is built as
+        {**sl_os_env_vars, **sl_env_vars} (starlake_airflow_bash_job.py:86).
+        """
+        task, env = self._make_load_task(backend)
+        for key, value in env.items():
+            assert task.env.get(key) == value, (
+                f"{backend}: task.env[{key!r}] = {task.env.get(key)!r}, "
+                f"expected {value!r}"
+            )

--- a/tests/airflow/test_airflow_runtime.py
+++ b/tests/airflow/test_airflow_runtime.py
@@ -43,7 +43,12 @@ from datetime import datetime, timezone
 
 import pytest
 
-from tests.shared.conftest import get_duckdb, restore_env, set_env
+from tests.shared.conftest import (
+    get_duckdb,
+    resolve_duckdb_connection_db_path,
+    restore_env,
+    set_env,
+)
 
 try:
     import airflow
@@ -436,3 +441,34 @@ class TestAirflowDatasetTriggering:
         condition_uris = {d.uri for d in condition.objects}
         assert "starbake_orders" in condition_uris
         assert "starbake_customers" in condition_uris
+
+
+# ===================================================================
+# TestConnectionEndToEnd (AC #2)
+# ===================================================================
+
+class TestConnectionEndToEnd:
+    """Data lands exactly where application.sl.yml's connection points.
+
+    The orchestrator never read the connection URL — Starlake CLI
+    resolved it from SL_ROOT/SL_ENV alone.  Re-deriving the location
+    from the user-facing YAML and finding the loaded rows there proves
+    the connection chain end-to-end.
+    """
+
+    def test_load_written_to_connection_url_database(self, executed_load_dags):
+        _, isolated, _ = executed_load_dags
+        db_path = resolve_duckdb_connection_db_path(isolated)
+        assert db_path == isolated / "datasets" / "duckdb.db"
+        assert db_path.is_file(), f"No DuckDB database at {db_path}"
+        conn = get_duckdb(isolated)
+        try:
+            customers = conn.execute(
+                "SELECT count(*) FROM starbake.customers"
+            ).fetchone()[0]
+            # MERGE NOTE: after PR #68 (tests/shared/expected_results.py)
+            # merges, use EXPECTED_ROW_COUNTS["customers"] instead of the
+            # literal 7 (matching the module's row-count tests above).
+            assert customers == 7, f"Expected 7 customers, got {customers}"
+        finally:
+            conn.close()

--- a/tests/dagster/test_dagster_connection_agnosticism.py
+++ b/tests/dagster/test_dagster_connection_agnosticism.py
@@ -1,0 +1,45 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.shared.connection_audit import find_connection_logic_violations
+
+_MODULE_SRC = (
+    Path(__file__).resolve().parents[2]
+    / "starlake-dagster" / "src" / "main" / "python" / "ai" / "starlake"
+)
+
+
+class TestDagsterConnectionAgnosticism:
+    """AC #4: no database-specific logic in the Dagster module.
+
+    Legitimate DB-flavoured vocabulary deliberately NOT flagged:
+    ``spark.datasource.bigquery.*`` Spark properties in the Dataproc
+    job are execution-environment tuning, not connection config.
+    """
+
+    def test_no_database_specific_logic(self):
+        assert _MODULE_SRC.is_dir(), f"Module source not found at {_MODULE_SRC}"
+        py_files, violations = find_connection_logic_violations(_MODULE_SRC)
+        # Sentinel guard: the scan must have covered the real module,
+        # not an empty directory (see feedback_test_assertion_quality).
+        assert any(p.name == "starlake_dagster_job.py" for p in py_files), (
+            f"Scan missed the module entry point; scanned: {py_files}"
+        )
+        assert violations == [], "\n".join(violations)

--- a/tests/dagster/test_dagster_connection_portability.py
+++ b/tests/dagster/test_dagster_connection_portability.py
@@ -1,0 +1,60 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from tests.dagster.dagster_test_mixin import DagsterTestMixin
+from tests.shared.base_test_connection_portability import (
+    BACKEND_ENVS,
+    BaseTestConnectionPortability,
+)
+
+
+class TestDagsterConnectionPortability(DagsterTestMixin, BaseTestConnectionPortability):
+    """Dagster pass-through: inherited base tests + op-closure env checks."""
+
+    def _get_op_env(self, task: Any) -> Dict[str, str]:
+        """Extract the ``env`` closure free var from the @op function.
+
+        Same closure-inspection technique as
+        DagsterTestMixin.get_task_arguments — the op passes this exact
+        dict to execute_shell_command(env=...) at runtime
+        (starlake_dagster_shell_job.py:172).
+        """
+        compute_fn = task._compute_fn
+        fn = getattr(compute_fn, "decorated_fn", compute_fn)
+        freevars = fn.__code__.co_freevars
+        assert "env" in freevars, f"'env' not captured by op closure: {freevars}"
+        return fn.__closure__[freevars.index("env")].cell_contents
+
+    @pytest.mark.parametrize("backend", sorted(BACKEND_ENVS))
+    def test_op_env_contains_backend_vars(self, backend):
+        """The op's subprocess env carries every backend var verbatim.
+
+        Dagster merges: env = os.environ.copy() + sl_env_vars
+        (starlake_dagster_shell_job.py:62-63) — sl_env_vars win.
+        """
+        task, env = self._make_load_task(backend)
+        op_env = self._get_op_env(task)
+        for key, value in env.items():
+            assert op_env.get(key) == value, (
+                f"{backend}: op env[{key!r}] = {op_env.get(key)!r}, "
+                f"expected {value!r}"
+            )

--- a/tests/dagster/test_dagster_runtime.py
+++ b/tests/dagster/test_dagster_runtime.py
@@ -36,7 +36,12 @@ import pytest
 
 from dagster import AssetKey, DagsterInstance
 
-from tests.shared.conftest import get_duckdb, restore_env, set_env
+from tests.shared.conftest import (
+    get_duckdb,
+    resolve_duckdb_connection_db_path,
+    restore_env,
+    set_env,
+)
 
 pytestmark = [
     pytest.mark.integration,
@@ -404,3 +409,34 @@ class TestDagsterDatasetTriggering:
             )
         finally:
             instance.dispose()
+
+
+# ===================================================================
+# TestConnectionEndToEnd (AC #2)
+# ===================================================================
+
+class TestConnectionEndToEnd:
+    """Data lands exactly where application.sl.yml's connection points.
+
+    The orchestrator never read the connection URL — Starlake CLI
+    resolved it from SL_ROOT/SL_ENV alone.  Re-deriving the location
+    from the user-facing YAML and finding the loaded rows there proves
+    the connection chain end-to-end.
+    """
+
+    def test_load_written_to_connection_url_database(self, executed_load_jobs):
+        _, isolated, _ = executed_load_jobs
+        db_path = resolve_duckdb_connection_db_path(isolated)
+        assert db_path == isolated / "datasets" / "duckdb.db"
+        assert db_path.is_file(), f"No DuckDB database at {db_path}"
+        conn = get_duckdb(isolated)
+        try:
+            customers = conn.execute(
+                "SELECT count(*) FROM starbake.customers"
+            ).fetchone()[0]
+            # MERGE NOTE: after PR #68 (tests/shared/expected_results.py)
+            # merges, use EXPECTED_ROW_COUNTS["customers"] instead of the
+            # literal 7 (matching the module's row-count tests above).
+            assert customers == 7, f"Expected 7 customers, got {customers}"
+        finally:
+            conn.close()

--- a/tests/shared/base_test_connection_portability.py
+++ b/tests/shared/base_test_connection_portability.py
@@ -1,0 +1,135 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ai.starlake.orchestration import StarlakeSchedule
+
+from tests.shared.base_test_orchestration import BaseTestOrchestration
+
+# Backend payloads mirror the Jinja variables documented in the starlake
+# `connection` skill for each backend's application.sl.yml block.  The
+# names are OPAQUE to the framework — that is precisely what these tests
+# prove.  Values must not contain ',' or '=' (the --options wire format
+# splits on both; that CLI-contract limitation is out of scope here).
+BACKEND_ENVS = {
+    "DUCKDB": {"SL_ENV": "DUCKDB"},
+    "BIGQUERY": {
+        "SL_ENV": "BIGQUERY",
+        "GCP_PROJECT": "test-project",
+        "GCP_TOKEN": "dummy-token",
+    },
+    "SNOWFLAKE": {
+        "SL_ENV": "SNOWFLAKE",
+        "SNOWFLAKE_ACCOUNT": "test-account",
+        "SNOWFLAKE_USER": "test-user",
+        "SNOWFLAKE_PASSWORD": "dummy-password",
+        "SNOWFLAKE_WAREHOUSE": "COMPUTE_WH",
+        "SNOWFLAKE_DB": "TEST_DB",
+        "SNOWFLAKE_SCHEMA": "PUBLIC",
+    },
+    "POSTGRESQL": {
+        "SL_ENV": "POSTGRESQL",
+        "POSTGRES_HOST": "localhost",
+        "POSTGRES_PORT": "5432",
+        "POSTGRES_DATABASE": "starlake",
+        "POSTGRES_USER": "test-user",
+        "POSTGRES_PASSWORD": "dummy-password",
+    },
+}
+
+# Markers that would betray orchestrator-side connection resolution if
+# they ever surfaced in a built CLI command.
+_CONNECTION_MARKERS = (
+    "connectionRef",
+    "jdbc:",
+    "--connection",
+    "org.duckdb",
+    "org.postgresql",
+)
+
+
+class BaseTestConnectionPortability(BaseTestOrchestration):
+    """Abstract base: connection configuration is passed through verbatim.
+
+    'Mocked CLI' here means the Starlake CLI is NEVER executed: the tests
+    build tasks through the full orchestration -> pipeline path and inspect
+    the command + environment the orchestrator WOULD hand to the CLI.
+    """
+
+    def _make_load_task(self, backend: str):
+        """Build a load task with the backend's env in sl_env_var."""
+        env = BACKEND_ENVS[backend]
+        options = {"sl_env_var": json.dumps(env)}
+        schedule = StarlakeSchedule(name=None, cron=None, domains=[])
+        pipeline = self.create_test_pipeline(schedule=schedule, options=options)
+        with pipeline:
+            node = pipeline.sl_load(
+                task_id="load_starbake_customers",
+                domain="starbake",
+                table="customers",
+            )
+        assert node is not None
+        return node.task, env
+
+    @pytest.mark.parametrize("backend", sorted(BACKEND_ENVS))
+    def test_backend_env_passthrough(self, backend):
+        """Every sl_env_var key=value reaches --options verbatim."""
+        task, env = self._make_load_task(backend)
+        args = self.get_task_arguments(task)
+        opts = self.get_arg_value(args, "--options")
+        for key, value in env.items():
+            assert f"{key}={value}" in opts, (
+                f"{backend}: expected '{key}={value}' in --options, got: {opts}"
+            )
+
+    @pytest.mark.parametrize("backend", sorted(BACKEND_ENVS))
+    def test_no_connection_arguments_injected(self, backend):
+        """The built command carries NO connection vocabulary of its own."""
+        task, _ = self._make_load_task(backend)
+        args = self.get_task_arguments(task)
+        assert args, "Expected a non-empty argument list"
+        joined = " ".join(args)
+        for marker in _CONNECTION_MARKERS:
+            assert marker not in joined, (
+                f"{backend}: connection marker '{marker}' leaked into: {joined}"
+            )
+
+    def test_command_identical_across_backends(self):
+        """Same load command modulo the opaque --options payload.
+
+        Proves there is no backend-specific transformation of the CLI
+        invocation: swapping the target warehouse changes ONLY the
+        forwarded environment, never the command structure.
+        """
+
+        def canonical(backend):
+            task, _ = self._make_load_task(backend)
+            args = list(self.get_task_arguments(task))
+            if "--options" in args:
+                args[args.index("--options") + 1] = "<OPTIONS>"
+            return args
+
+        reference = canonical("DUCKDB")
+        assert reference, "Expected a non-empty canonical argument list"
+        for backend in ("BIGQUERY", "SNOWFLAKE", "POSTGRESQL"):
+            assert canonical(backend) == reference, (
+                f"Command structure diverged for backend {backend}"
+            )

--- a/tests/shared/conftest.py
+++ b/tests/shared/conftest.py
@@ -218,6 +218,24 @@ def get_duckdb(project_path: Path) -> duckdb.DuckDBPyConnection:
     )
 
 
+def resolve_duckdb_connection_db_path(project_path: Path) -> Path:
+    """Resolve the DuckDB database path declared in application.sl.yml.
+
+    Parses the ``jdbc:duckdb:`` connection URL exactly as a user wrote it
+    and substitutes ``{{SL_ROOT}}`` — proving where Starlake CLI was TOLD
+    to write, independently of where the tests know it writes.
+    """
+    import yaml
+
+    config = yaml.safe_load(
+        (project_path / "metadata" / "application.sl.yml").read_text()
+    )
+    url = config["application"]["connections"]["duckdb"]["options"]["url"]
+    prefix = "jdbc:duckdb:"
+    assert url.startswith(prefix), f"Unexpected connection URL: {url}"
+    return Path(url[len(prefix):].replace("{{SL_ROOT}}", str(project_path)))
+
+
 # ---------------------------------------------------------------------------
 # Runtime fixtures — module-scoped, parameterised via ``runtime_config``
 # ---------------------------------------------------------------------------

--- a/tests/shared/connection_audit.py
+++ b/tests/shared/connection_audit.py
@@ -1,0 +1,133 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+# Connection-configuration vocabulary that must never appear in an
+# orchestrator module: resolving any of these is Starlake CLI's job.
+FORBIDDEN_TEXT_PATTERNS: Tuple[str, ...] = (
+    "connectionRef",
+    "application.sl.yml",
+    "jdbc:duckdb",
+    "jdbc:postgresql",
+    "jdbc:snowflake",
+    "jdbc:redshift",
+    "jdbc:mysql",
+    "org.duckdb.DuckDBDriver",
+    "org.postgresql.Driver",
+    "net.snowflake.client.jdbc",
+    "com.amazon.redshift",
+)
+
+# Warehouse/database CLIENT libraries.  Orchestrator platform SDKs are NOT
+# listed: sqlalchemy (Airflow metadata DB), google.cloud.run_v2 (Cloud Run
+# execution environment) and airflow.providers.google (Dataproc operators)
+# are orchestrator/compute concerns, not data-warehouse connections.
+# ai.starlake.odbc is the core's SQL-session executor (DuckDBSession,
+# SnowflakeSession, ...) — importing it from an orchestrator module would
+# smuggle database logic in indirectly, so it is forbidden here.  It must
+# stay OUT of FORBIDDEN_TEXT_PATTERNS: the string appears in a list literal
+# at starlake-snowflake/.../helper/__init__.py:36 (not an import).
+FORBIDDEN_IMPORT_ROOTS: Tuple[str, ...] = (
+    "duckdb",
+    "psycopg2",
+    "psycopg",
+    "google.cloud.bigquery",
+    "snowflake",           # allowlisted per-module (snowpark/core = platform SDK)
+    "databricks",
+    "redshift_connector",
+    "pymysql",
+    "mysql",
+    "ai.starlake.odbc",
+)
+
+
+def _matches(name: str, roots: Sequence[str]) -> bool:
+    return any(name == r or name.startswith(r + ".") for r in roots)
+
+
+def _resolve_relative_base(py: Path, module_src: Path, level: int) -> str:
+    """Resolve the base package of a relative import to a dotted name.
+
+    ``module_src`` points at the scanned ``.../ai/starlake`` package
+    directory, so the package of ``.../ai/starlake/airflow/bash/x.py``
+    is ``ai.starlake.airflow.bash``.  Relative imports matter because
+    the shared ``ai.starlake`` namespace makes ``from ..odbc import X``
+    inside an orchestrator module resolve to ``ai.starlake.odbc`` —
+    skipping them would leave a bypass in the audit fence.
+
+    Returns ``""`` when *level* escapes the scanned tree (such an import
+    would fail at runtime anyway).
+    """
+    pkg = ("ai", "starlake") + py.parent.relative_to(module_src).parts
+    if level - 1 >= len(pkg):
+        return ""
+    base = pkg[: len(pkg) - (level - 1)] if level > 1 else pkg
+    return ".".join(base)
+
+
+def find_connection_logic_violations(
+    module_src: Path,
+    allowed_import_prefixes: Sequence[str] = (),
+) -> Tuple[List[Path], List[str]]:
+    """Scan an orchestrator module's source tree for database-specific logic.
+
+    Returns ``(scanned_files, violations)``.  Excludes stale ``build/``
+    artifacts and ``__pycache__``.  Callers must assert on BOTH values so
+    the audit cannot silently pass by scanning zero files.
+
+    ``from X import Y`` is checked as ``X.Y`` (not just ``X``) so the
+    idiomatic ``from google.cloud import bigquery`` cannot slip past the
+    ``google.cloud.bigquery`` root; relative imports are resolved against
+    the file's package for the same reason (see _resolve_relative_base).
+    """
+    py_files = [
+        p
+        for p in sorted(module_src.rglob("*.py"))
+        if "build" not in p.parts and "__pycache__" not in p.parts
+    ]
+    violations: List[str] = []
+    for py in py_files:
+        text = py.read_text()
+        for pattern in FORBIDDEN_TEXT_PATTERNS:
+            if pattern in text:
+                violations.append(f"{py}: contains forbidden pattern '{pattern}'")
+        tree = ast.parse(text)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                if node.level == 0:
+                    base = node.module or ""
+                else:
+                    base = _resolve_relative_base(py, module_src, node.level)
+                    if node.module:
+                        base = f"{base}.{node.module}" if base else node.module
+                if not base:
+                    continue
+                names = [base] + [f"{base}.{alias.name}" for alias in node.names]
+            else:
+                continue
+            for name in names:
+                if _matches(name, FORBIDDEN_IMPORT_ROOTS) and not _matches(
+                    name, allowed_import_prefixes
+                ):
+                    violations.append(f"{py}: imports database client '{name}'")
+    return py_files, violations

--- a/tests/snowflake/test_snowflake_connection_agnosticism.py
+++ b/tests/snowflake/test_snowflake_connection_agnosticism.py
@@ -1,0 +1,49 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.shared.connection_audit import find_connection_logic_violations
+
+_MODULE_SRC = (
+    Path(__file__).resolve().parents[2]
+    / "starlake-snowflake" / "src" / "main" / "python" / "ai" / "starlake"
+)
+
+
+class TestSnowflakeConnectionAgnosticism:
+    """AC #4: no database-specific logic in the Snowflake module.
+
+    ``snowflake.snowpark`` / ``snowflake.core`` are the orchestrator
+    platform SDK — Snowflake IS the orchestrator here, so they are
+    allowlisted.  ``snowflake.connector`` (the warehouse client) stays
+    forbidden even in this module.
+    """
+
+    def test_no_database_specific_logic(self):
+        assert _MODULE_SRC.is_dir(), f"Module source not found at {_MODULE_SRC}"
+        py_files, violations = find_connection_logic_violations(
+            _MODULE_SRC,
+            allowed_import_prefixes=("snowflake.snowpark", "snowflake.core"),
+        )
+        # Sentinel guard: the scan must have covered the real module,
+        # not an empty directory (see feedback_test_assertion_quality).
+        assert any(p.name == "starlake_snowflake_job.py" for p in py_files), (
+            f"Scan missed the module entry point; scanned: {py_files}"
+        )
+        assert violations == [], "\n".join(violations)

--- a/tests/snowflake/test_snowflake_connection_portability.py
+++ b/tests/snowflake/test_snowflake_connection_portability.py
@@ -1,0 +1,75 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import pytest
+
+from tests.snowflake.snowflake_test_mixin import SnowflakeTestMixin
+from tests.shared.base_test_connection_portability import (
+    BaseTestConnectionPortability,
+)
+
+
+class TestSnowflakeConnectionPortability(SnowflakeTestMixin, BaseTestConnectionPortability):
+    """Snowflake runs Starlake INSIDE Snowflake — the connection model differs.
+
+    The connection from application.sl.yml is consumed by `starlake
+    dag-generate` when it compiles the SQL statements embedded in the
+    generated DAG module; at runtime the 'connection' is the Snowpark
+    Session the DAGTask executes under.  There is no CLI subprocess and
+    therefore no env/--options channel to pass connection config through.
+    The framework still contains ZERO connection transformation logic
+    (see test_snowflake_connection_agnosticism.py) — which is the actual
+    portability guarantee this story validates.
+
+    test_no_connection_arguments_injected and
+    test_command_identical_across_backends are inherited and PASS: the
+    reconstructed task arguments carry no connection vocabulary and are
+    identical for every backend payload.
+    """
+
+    @pytest.mark.xfail(
+        strict=True,
+        raises=AssertionError,
+        reason=(
+            "sl_env_vars are not forwarded to Snowflake task runtime: "
+            "sl_job() merges them into a local 'options' dict "
+            "(starlake_snowflake_job.py:302-313) that is never used; the "
+            "SQL executor's connection is the Snowpark Session, applied "
+            "at dag-generate time — see issue #77"
+        ),
+    )
+    @pytest.mark.parametrize(
+        "backend", ["BIGQUERY", "DUCKDB", "POSTGRESQL", "SNOWFLAKE"]
+    )
+    def test_backend_env_passthrough(self, backend):
+        super().test_backend_env_passthrough(backend)
+
+    def test_sl_env_vars_not_forwarded_to_task_runtime(self):
+        """Documents the current contract: no closure captures the merged
+        sl_env_vars.  If the framework ever starts forwarding them (the
+        confirmed direction of issue #77), this test fails and the xfail
+        above must be revisited together with the issue.
+        """
+        task, _ = self._make_load_task("BIGQUERY")
+        func = task.definition.func
+        assert func is not None
+        assert "options" not in func.__code__.co_freevars, (
+            "Snowflake task closure now captures 'options' — sl_env_vars "
+            "forwarding has changed (issue #77); revisit the xfail in "
+            "this class"
+        )


### PR DESCRIPTION
## Summary

Validation-only test layer proving cross-orchestrator database connection portability: generated DAGs work with any configured database connection because the orchestration framework never reads, parses, or transforms connection configuration — that is entirely Starlake CLI's job (`SL_ENV` → `env.<SL_ENV>.sl.yml` → `application.connections`). No production code changes; all files under `tests/`.

- **Shared audit helper** `tests/shared/connection_audit.py`: AST-based per-module scan — exact forbidden connection vocabulary (`connectionRef`, `jdbc:` URLs, driver class names) + forbidden warehouse-client import roots (`duckdb`, `psycopg2`, `google.cloud.bigquery`, `snowflake` with per-module `snowflake.snowpark`/`snowflake.core` allowlist, `ai.starlake.odbc` as import-root fence only). The import scan checks `from X import Y` as `X.Y` and resolves relative imports against the file's package, so neither `from google.cloud import bigquery` nor `from ..odbc import ...` can bypass the fence (code-review hardening).
- **Shared pass-through base** `tests/shared/base_test_connection_portability.py`: DuckDB/BigQuery/Snowflake/PostgreSQL payloads, mocked CLI (the built command/env is inspected; the CLI never runs): every `sl_env_var` key=value reaches `--options` verbatim, no connection vocabulary is injected, command structure is identical across backends.
- **Airflow** (both majors): + `test_operator_env_contains_backend_vars` — `task.env` is the FULL subprocess environment (SubprocessHook replaces `os.environ`).
- **Dagster**: + `test_op_env_contains_backend_vars` — op-closure `env` free-var inspection.
- **Snowflake** (honest divergence): `test_backend_env_passthrough` is `xfail(strict=True, raises=AssertionError)` + a closure-shape sentinel — `sl_env_vars` are merged into a local `options` dict that never reaches task runtime (#77 tracks the confirmed forwarding fix; when it lands the xfail XPASSes loudly).
- **Per-module connection-agnosticism audits** with sentinel-file guards (scan can never pass on an empty directory).
- **DuckDB end-to-end** (`TestConnectionEndToEnd` in both runtime suites): `resolve_duckdb_connection_db_path()` re-derives the write location from the user-facing `jdbc:duckdb:` URL in `application.sl.yml` and asserts the loaded rows are exactly there — riding the existing module-scoped load executions, zero extra CLI runs.

## Test results (local CI-equivalent, py3.11, non-editable worktree-source installs)

| Leg | Result |
| --- | --- |
| orchestration + shared | 114 passed |
| airflow 2.10.5 | 139 passed |
| airflow 3.3.0 | 130 passed + 9 pre-existing skips |
| dagster 1.9.13 | 100 passed |
| snowflake | 68 passed + 11 xfailed (7 pre-existing + 4 new strict) |

## Merge notes (Epic 3 dev wave — sibling PRs #66, #68, #73, #75)

- `tests/shared/conftest.py`: this PR adds one utility function (`resolve_duckdb_connection_db_path`) next to `get_duckdb`; PR #66 adds fixtures to the same file — both edits are purely additive, no name overlap.
- `tests/airflow/test_airflow_runtime.py` / `tests/dagster/test_dagster_runtime.py`: this PR widens the `tests.shared.conftest` import block and APPENDS one `TestConnectionEndToEnd` class at end of file. PR #68 rewrites the row-count regions and adds `tests.shared.expected_results` imports at the top; story 3.4 swaps the Dataset/Asset alias header of the airflow file — all regions are disjoint, merge the import blocks rather than duplicating.
- After PR #68 merges: replace the literal `7` in both `TestConnectionEndToEnd` classes with `EXPECTED_ROW_COUNTS["customers"]` from `tests.shared.expected_results` (MERGE NOTE comments mark the spots).

Closes #81
Refs #76
Refs #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)
