### PR TITLE
Story 3.4 — Cross-orchestrator dataset triggering strategy validation

### DIFF
--- a/starlake-dagster/src/main/python/ai/starlake/dagster/starlake_dagster_orchestration.py
+++ b/starlake-dagster/src/main/python/ai/starlake/dagster/starlake_dagster_orchestration.py
@@ -106,7 +106,12 @@ class DagsterOrchestration(AbstractOrchestration[JobDefinition, OpDefinition, Gr
                                 f"but not for {not_materialized_asset_key_strs}"
                             )
                         else:
-                            # If all datasets were materialized, we run the pipeline
+                            # If all datasets were materialized, we run the pipeline.
+                            # Advance the cursor so the handled materializations are
+                            # not re-consumed on the next tick — without it Dagster
+                            # raises DagsterInvalidDefinitionError on any tick that
+                            # yields runs (issue #80).
+                            context.advance_cursor(asset_events)
                             return RunRequest(
                                 run_config=dg_pipeline._ops_config(logical_datetime=None, sl_options=sl_options) if sl_options else None,
                             )
@@ -128,6 +133,9 @@ class DagsterOrchestration(AbstractOrchestration[JobDefinition, OpDefinition, Gr
 
                     # if there are no datasets to check, we run the pipeline
                     if len(datasets_to_check) == 0:
+                        # Advance the cursor before yielding the run (issue #80),
+                        # mirroring the freshness-checked path below.
+                        context.advance_cursor(asset_events)
                         return RunRequest(
                             run_config=dg_pipeline._ops_config(logical_datetime=None, sl_options=sl_options) if sl_options else None,
                         )

--- a/tests/airflow/dataset_compat.py
+++ b/tests/airflow/dataset_compat.py
@@ -1,0 +1,46 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Version-agnostic Dataset/Asset aliases for the Airflow test modules.
+
+Airflow 2 names (Dataset/DatasetAll/DatasetAny, timetable.dataset_condition)
+map to Airflow 3 assets (Asset/AssetAll/AssetAny, timetable.asset_condition).
+Extracted from test_airflow_runtime.py so every Airflow test module shares
+one alias block.
+"""
+
+from __future__ import annotations
+
+try:
+    import airflow
+
+    AIRFLOW_AVAILABLE = True
+    AIRFLOW_VERSION = tuple(int(x) for x in airflow.__version__.split(".")[:2])
+    SUPPORTS_ASSETS = AIRFLOW_VERSION >= (3, 0)
+    if SUPPORTS_ASSETS:
+        from airflow.sdk import Asset as Dataset
+        from airflow.sdk import AssetAll as DatasetAll
+        from airflow.sdk import AssetAny as DatasetAny
+    else:
+        from airflow.datasets import Dataset, DatasetAll, DatasetAny
+except ImportError:  # pragma: no cover — collection guard only
+    AIRFLOW_AVAILABLE = False
+    AIRFLOW_VERSION = (0, 0)
+    SUPPORTS_ASSETS = False
+    Dataset = DatasetAll = DatasetAny = None
+
+# Name of the condition attribute on dataset/asset-triggered timetables.
+CONDITION_ATTR = "asset_condition" if SUPPORTS_ASSETS else "dataset_condition"

--- a/tests/airflow/test_airflow_runtime.py
+++ b/tests/airflow/test_airflow_runtime.py
@@ -45,24 +45,21 @@ import pytest
 
 from tests.shared.conftest import get_duckdb, restore_env, set_env
 
-try:
-    import airflow
+from tests.airflow.dataset_compat import (
+    AIRFLOW_AVAILABLE,
+    AIRFLOW_VERSION,
+    SUPPORTS_ASSETS,
+    Dataset,
+    DatasetAll,
+    DatasetAny,
+    CONDITION_ATTR as _CONDITION_ATTR,
+)
 
-    AIRFLOW_AVAILABLE = True
-    AIRFLOW_VERSION = tuple(int(x) for x in airflow.__version__.split(".")[:2])
-    SUPPORTS_ASSETS = AIRFLOW_VERSION >= (3, 0)
-    if SUPPORTS_ASSETS:
-        from airflow.sdk import Asset as Dataset
-        from airflow.sdk import AssetAll as DatasetAll
-        from airflow.sdk import AssetAny as DatasetAny
-    else:
-        from airflow.datasets import Dataset, DatasetAll, DatasetAny
+try:
     from airflow.models.dag import DAG
     from airflow.utils.state import DagRunState
-except ImportError:
-    AIRFLOW_AVAILABLE = False
-    AIRFLOW_VERSION = (0, 0)
-    SUPPORTS_ASSETS = False
+except ImportError:  # pragma: no cover — collection guard only
+    pass
 
 pytestmark = [
     pytest.mark.integration,
@@ -71,9 +68,6 @@ pytestmark = [
         reason="Requires Apache Airflow",
     ),
 ]
-
-# The name of the condition attribute on dataset/asset-triggered timetables.
-_CONDITION_ATTR = "asset_condition" if SUPPORTS_ASSETS else "dataset_condition"
 
 # Use "now" as execution date — the DAG's start_date is derived from
 # the generated file's mtime, which is always "today".  An execution

--- a/tests/airflow/test_airflow_triggering_strategy.py
+++ b/tests/airflow/test_airflow_triggering_strategy.py
@@ -1,0 +1,181 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Airflow triggering-strategy validation (dual-version: Airflow 2 and 3).
+
+Structure tests (condition class family + member URIs) run identically on
+both majors via the Dataset/Asset alias block; the ``evaluate()``
+truth-table tests are Airflow-2-only (Airflow 3 removed ``evaluate()``
+from the SDK asset classes — evaluation moved server-side).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.airflow.airflow_test_mixin import AirflowTestMixin
+from tests.airflow.dataset_compat import (
+    AIRFLOW_AVAILABLE,
+    CONDITION_ATTR,
+    SUPPORTS_ASSETS,
+    Dataset,
+    DatasetAll,
+    DatasetAny,
+)
+from tests.shared.base_test_triggering_strategy import BaseTestTriggeringStrategy
+from tests.shared.triggering_scenarios import (
+    EXPECTED_URIS,
+    NO_UPSTREAM,
+    SINGLE_UPSTREAM,
+    TWO_UPSTREAMS,
+    make_dependencies,
+)
+
+pytestmark = pytest.mark.skipif(
+    not AIRFLOW_AVAILABLE, reason="Requires Apache Airflow"
+)
+
+
+class TestAirflowTriggeringStrategy(AirflowTestMixin, BaseTestTriggeringStrategy):
+    """Airflow concrete implementation of the shared triggering tests."""
+
+
+def _make_pipeline(strategy, upstreams, filename):
+    """Build an Airflow pipeline through the real orchestration path.
+
+    Deliberately does NOT reuse ``AirflowTestMixin.create_orchestration``:
+    the structure/semantics classes below are plain classes (no
+    mixin/base inheritance), and per-test ``filename``s give each DAG a
+    distinct ``pipeline_id`` (better failure messages).
+    """
+    from ai.starlake.airflow import AirflowOrchestration
+    from ai.starlake.airflow.bash import StarlakeAirflowBashJob
+    from tests.airflow.conftest import _AIRFLOW_TEST_MODULE_NAME
+
+    job = StarlakeAirflowBashJob(
+        filename=filename,
+        module_name=_AIRFLOW_TEST_MODULE_NAME,
+        options={"dataset_triggering_strategy": strategy},
+    )
+    orch = AirflowOrchestration(job=job)
+    pipeline = orch.sl_create_pipeline(
+        dependencies=make_dependencies(upstreams)
+    )
+    with pipeline:
+        pass
+    return pipeline
+
+
+def _condition(pipeline):
+    timetable = pipeline.dag.timetable
+    assert hasattr(timetable, CONDITION_ATTR), (
+        f"Timetable {type(timetable).__name__} has no {CONDITION_ATTR}"
+    )
+    return getattr(timetable, CONDITION_ATTR)
+
+
+class TestAirflowTriggeringStructure:
+    """Condition structure — runs identically on Airflow 2 and 3."""
+
+    def test_any_two_upstreams_condition_is_or(self):
+        pipeline = _make_pipeline("any", TWO_UPSTREAMS, "test_any_or.py")
+        condition = _condition(pipeline)
+        assert isinstance(condition, DatasetAny), (
+            f"Expected {DatasetAny.__name__}, got {type(condition).__name__}"
+        )
+        assert {d.uri for d in condition.objects} == set(
+            EXPECTED_URIS[TWO_UPSTREAMS]
+        )
+
+    def test_all_two_upstreams_condition_is_and(self):
+        pipeline = _make_pipeline("all", TWO_UPSTREAMS, "test_all_and.py")
+        condition = _condition(pipeline)
+        assert isinstance(condition, DatasetAll), (
+            f"Expected {DatasetAll.__name__}, got {type(condition).__name__}"
+        )
+        assert {d.uri for d in condition.objects} == set(
+            EXPECTED_URIS[TWO_UPSTREAMS]
+        )
+
+    @pytest.mark.parametrize("strategy", ["any", "all"])
+    def test_single_upstream_condition_is_bare_event(self, strategy):
+        """reduce() over one event returns the event itself — for BOTH
+        strategies the condition is a plain Dataset/Asset."""
+        pipeline = _make_pipeline(
+            strategy, SINGLE_UPSTREAM, f"test_single_{strategy}.py"
+        )
+        condition = _condition(pipeline)
+        assert isinstance(condition, Dataset), (
+            f"Expected bare {Dataset.__name__} for single upstream, "
+            f"got {type(condition).__name__}"
+        )
+        assert condition.uri == "starbake_orders"
+
+    @pytest.mark.parametrize("strategy", ["any", "all"])
+    def test_no_upstream_dag_is_not_dataset_triggered(self, strategy):
+        pipeline = _make_pipeline(
+            strategy, NO_UPSTREAM, f"test_none_{strategy}.py"
+        )
+        assert pipeline.events == []
+        timetable_cls = type(pipeline.dag.timetable).__name__
+        assert "Dataset" not in timetable_cls and "Asset" not in timetable_cls, (
+            f"DAG without upstreams must not be dataset-triggered, "
+            f"got {timetable_cls}"
+        )
+
+    def test_mixed_strategies_independent_pipelines(self):
+        """Two pipelines with different strategies diverge structurally."""
+        p_any = _make_pipeline("any", TWO_UPSTREAMS, "test_mixed_any.py")
+        p_all = _make_pipeline("all", TWO_UPSTREAMS, "test_mixed_all.py")
+        assert isinstance(_condition(p_any), DatasetAny)
+        assert isinstance(_condition(p_all), DatasetAll)
+
+
+@pytest.mark.skipif(
+    SUPPORTS_ASSETS,
+    reason=(
+        "Airflow 3 removed BaseAsset.evaluate() from the SDK — evaluation "
+        "is server-side (AssetEvaluator + session). Semantics on 3.x are "
+        "covered by the structural tests above (same class family, same "
+        "member URIs, evaluated by the identical serialized agg_func)."
+    ),
+)
+class TestAirflowTriggeringSemantics:
+    """Truth-table on the native condition objects (Airflow 2 only)."""
+
+    def test_any_triggers_on_first_available(self):
+        pipeline = _make_pipeline("any", TWO_UPSTREAMS, "test_sem_any.py")
+        condition = _condition(pipeline)
+        first_uri = next(iter(EXPECTED_URIS[TWO_UPSTREAMS]))
+        assert condition.evaluate({first_uri: True}) is True
+        assert condition.evaluate({}) is False
+
+    def test_all_waits_for_all(self):
+        pipeline = _make_pipeline("all", TWO_UPSTREAMS, "test_sem_all.py")
+        condition = _condition(pipeline)
+        uris = set(EXPECTED_URIS[TWO_UPSTREAMS])
+        first_uri = next(iter(uris))
+        assert condition.evaluate({first_uri: True}) is False
+        assert condition.evaluate({u: True for u in uris}) is True
+
+    @pytest.mark.parametrize("strategy", ["any", "all"])
+    def test_single_upstream_triggers_on_its_event(self, strategy):
+        pipeline = _make_pipeline(
+            strategy, SINGLE_UPSTREAM, f"test_sem_single_{strategy}.py"
+        )
+        condition = _condition(pipeline)
+        assert condition.evaluate({"starbake_orders": True}) is True
+        assert condition.evaluate({}) is False

--- a/tests/dagster/test_dagster_triggering_strategy.py
+++ b/tests/dagster/test_dagster_triggering_strategy.py
@@ -1,0 +1,192 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Dagster triggering-strategy validation.
+
+Sensor-tick semantics with real (runless) asset materializations —
+pattern per tests/dagster/test_dagster_runtime.py::
+TestDagsterDatasetTriggering (persistent DagsterInstance.local_temp,
+build_multi_asset_sensor_context, evaluate_tick).
+
+Dagster ANY semantics are maintainer-confirmed DESIGN (2026-07-14,
+issue #78): ANY governs the sensor's trigger gate only; before a run,
+the post-gate consistency check verifies ALL non-optional monitored
+datasets — see test_any_partial_materialization_skips_by_design.
+
+The positive trigger paths (RunRequest for runless materializations)
+depend on the sensor advancing its cursor — issue #80, fixed alongside
+these tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.dagster.dagster_test_mixin import DagsterTestMixin
+from tests.shared.base_test_triggering_strategy import BaseTestTriggeringStrategy
+from tests.shared.triggering_scenarios import (
+    NO_UPSTREAM,
+    SINGLE_UPSTREAM,
+    TWO_UPSTREAMS,
+    make_dependencies,
+)
+
+
+class TestDagsterTriggeringStrategy(DagsterTestMixin, BaseTestTriggeringStrategy):
+    """Dagster concrete implementation of the shared triggering tests."""
+
+
+class TestDagsterTriggeringSemantics:
+    """Sensor-tick semantics with real (runless) asset materializations."""
+
+    def _build(self, strategy, upstreams, filename):
+        from ai.starlake.dagster import DagsterOrchestration
+        from ai.starlake.dagster.shell import StarlakeDagsterShellJob
+        from tests.dagster.conftest import _DAGSTER_TEST_MODULE_NAME
+
+        job = StarlakeDagsterShellJob(
+            filename=filename,
+            module_name=_DAGSTER_TEST_MODULE_NAME,
+            options={"dataset_triggering_strategy": strategy},
+        )
+        with DagsterOrchestration(job=job) as orch:
+            pipeline = orch.sl_create_pipeline(
+                dependencies=make_dependencies(upstreams)
+            )
+            with pipeline:
+                pass
+        return pipeline, orch
+
+    def _evaluate_tick(self, orch, monitored_uris, materialized_uris, tmp_path):
+        from dagster import (
+            AssetKey,
+            AssetMaterialization,
+            DagsterInstance,
+            build_multi_asset_sensor_context,
+        )
+
+        sensors = orch.definitions.sensors
+        assert len(sensors) == 1, "Expected 1 sensor, got {}".format(
+            len(sensors)
+        )
+        instance = DagsterInstance.local_temp(tempdir=str(tmp_path))
+        try:
+            for uri in materialized_uris:
+                instance.report_runless_asset_event(
+                    AssetMaterialization(asset_key=AssetKey(uri))
+                )
+            context = build_multi_asset_sensor_context(
+                monitored_assets=[AssetKey(uri) for uri in monitored_uris],
+                instance=instance,
+                definitions=orch.definitions,
+            )
+            return sensors[0].evaluate_tick(context)
+        finally:
+            instance.dispose()
+
+    @pytest.mark.parametrize("strategy", ["any", "all"])
+    def test_single_upstream_materialization_triggers(
+        self, tmp_path, strategy
+    ):
+        """Both strategies fire once the only monitored asset materializes."""
+        _, orch = self._build(
+            strategy, SINGLE_UPSTREAM, "test_trig_single_{}.py".format(strategy)
+        )
+        result = self._evaluate_tick(
+            orch, ["starbake_orders"], ["starbake_orders"], tmp_path
+        )
+        assert len(result.run_requests) == 1, (
+            "Expected 1 RunRequest for {} with its single upstream "
+            "materialized, got {}".format(strategy, len(result.run_requests))
+        )
+
+    def test_all_partial_materialization_skips(self, tmp_path):
+        """ALL waits: 1 of 2 monitored assets materialized -> no run.
+
+        Under ALL the partial materialization is rejected at the TRIGGER
+        GATE itself (``all()`` over the latest materialization records),
+        so the skip message is the gate-level one.
+        """
+        _, orch = self._build(
+            "all", TWO_UPSTREAMS, "test_trig_all_partial.py"
+        )
+        result = self._evaluate_tick(
+            orch,
+            ["starbake_orders", "starbake_customers"],
+            ["starbake_orders"],
+            tmp_path,
+        )
+        assert len(result.run_requests) == 0
+        assert result.skip_message == "No materializations observed"
+
+    def test_all_complete_materialization_triggers(self, tmp_path):
+        """ALL fires once every monitored asset has materialized."""
+        _, orch = self._build(
+            "all", TWO_UPSTREAMS, "test_trig_all_complete.py"
+        )
+        result = self._evaluate_tick(
+            orch,
+            ["starbake_orders", "starbake_customers"],
+            ["starbake_orders", "starbake_customers"],
+            tmp_path,
+        )
+        assert len(result.run_requests) == 1
+
+    def test_any_partial_materialization_skips_by_design(self, tmp_path):
+        """BEHAVIOR PIN (issue #78 — maintainer-confirmed design, 2026-07-14).
+
+        With ``dataset_triggering_strategy=any`` and 1 of 2 monitored
+        assets materialized, the sensor passes the ``any()`` trigger
+        gate but the POST-GATE consistency check returns a SkipReason:
+        ANY governs the trigger gate only; before running, the pipeline
+        must verify the freshness of ALL the datasets it depends on
+        within the window frame.  This intentionally diverges from
+        Airflow's ``DatasetAny`` (which fires on the first available
+        upstream).
+
+        The skip message is asserted to be the POST-GATE one ("but not
+        for ...") — NOT the gate-level "No materializations observed" —
+        so this pin cannot pass for the wrong reason (canary rule: the
+        positive tests above prove runless materializations are visible
+        to the sensor context).  If the design ruling is ever revisited,
+        this pin flips loudly.
+        """
+        _, orch = self._build(
+            "any", TWO_UPSTREAMS, "test_trig_any_partial.py"
+        )
+        result = self._evaluate_tick(
+            orch,
+            ["starbake_orders", "starbake_customers"],
+            ["starbake_orders"],
+            tmp_path,
+        )
+        assert len(result.run_requests) == 0
+        skip_message = result.skip_message or ""
+        assert "but not for" in skip_message, (
+            "Expected the POST-GATE consistency SkipReason "
+            "('Observed materializations for ..., but not for ...'), "
+            "got: {!r}".format(result.skip_message)
+        )
+        assert "starbake_customers" in skip_message
+
+    @pytest.mark.parametrize("strategy", ["any", "all"])
+    def test_no_upstream_produces_no_sensor(self, strategy):
+        """No datasets and no cron -> neither sensor nor schedule."""
+        _, orch = self._build(
+            strategy, NO_UPSTREAM, "test_trig_none_{}.py".format(strategy)
+        )
+        assert len(orch.definitions.sensors) == 0
+        assert len(orch.definitions.schedules) == 0

--- a/tests/shared/base_test_triggering_strategy.py
+++ b/tests/shared/base_test_triggering_strategy.py
@@ -1,0 +1,139 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from ai.starlake.dataset import DatasetTriggeringStrategy
+from ai.starlake.orchestration import AbstractPipeline
+
+from tests.shared.base_test_orchestration import BaseTestOrchestration
+from tests.shared.triggering_scenarios import (
+    EXPECTED_URIS,
+    MIXED_UPSTREAMS,
+    NO_UPSTREAM,
+    SINGLE_UPSTREAM,
+    TWO_UPSTREAMS,
+    make_dependencies,
+)
+
+
+class BaseTestTriggeringStrategy(BaseTestOrchestration):
+    """Shared, orchestrator-agnostic triggering-strategy tests.
+
+    Only uses framework surface that already exists on every
+    orchestrator (pipeline.events / pipeline.datasets /
+    job.dataset_triggering_strategy) — the native ``|``/``&``
+    combination semantics are validated in each orchestrator's
+    test_{orch}_triggering_strategy.py module.
+
+    Adds ZERO abstract members: everything needed is already exposed
+    by ``BaseTestOrchestration.create_test_pipeline`` and the pipeline
+    / job properties.
+    """
+
+    def _make_pipeline(
+        self,
+        upstreams: Tuple[Tuple[str, Optional[str]], ...],
+        strategy: Optional[str] = None,
+    ) -> AbstractPipeline:
+        options = (
+            {"dataset_triggering_strategy": strategy} if strategy else None
+        )
+        return self.create_test_pipeline(
+            dependencies=make_dependencies(upstreams),
+            options=options,
+        )
+
+    def test_default_strategy_is_any(self):
+        """No option provided -> job strategy defaults to ANY."""
+        pipeline = self._make_pipeline(TWO_UPSTREAMS)
+        with pipeline:
+            pass
+        assert (
+            pipeline.job.dataset_triggering_strategy
+            == DatasetTriggeringStrategy.ANY
+        )
+
+    def test_invalid_strategy_falls_back_to_any(self):
+        """PIN: an invalid strategy string silently falls back to ANY.
+
+        Current behavior (ai/starlake/job/starlake_job.py — the
+        ``dataset_triggering_strategy`` option resolution): an invalid
+        string is silently replaced by the default (ANY), no error.
+        Whether it should raise instead is a follow-up product decision
+        (the sibling pre_load_strategy option IS strict); if strict
+        validation is ever extended to this option, this pin flipping
+        to ValueError is the intended signal — not a flake.
+        """
+        pipeline = self._make_pipeline(TWO_UPSTREAMS, strategy="bogus")
+        with pipeline:
+            pass
+        assert (
+            pipeline.job.dataset_triggering_strategy
+            == DatasetTriggeringStrategy.ANY
+        )
+
+    def test_two_upstreams_produce_two_events(self):
+        pipeline = self._make_pipeline(TWO_UPSTREAMS)
+        with pipeline:
+            pass
+        events = pipeline.events
+        # events is annotated Optional but is always a list — the guard
+        # is executable documentation of that misleading annotation.
+        assert events is not None
+        assert len(events) == len(TWO_UPSTREAMS)
+
+    def test_single_upstream_produces_single_event(self):
+        pipeline = self._make_pipeline(SINGLE_UPSTREAM)
+        with pipeline:
+            pass
+        assert len(pipeline.events) == 1
+
+    def test_no_upstream_produces_no_events(self):
+        """events is an EMPTY LIST (not None) when there are no upstreams."""
+        pipeline = self._make_pipeline(NO_UPSTREAM)
+        with pipeline:
+            pass
+        assert pipeline.events == []
+        assert pipeline.cron is None
+
+    def test_mixed_upstreams_partition_scheduled_and_not_scheduled(self):
+        """cron-less upstreams land in not_scheduled_datasets."""
+        pipeline = self._make_pipeline(MIXED_UPSTREAMS)
+        with pipeline:
+            pass
+        assert len(pipeline.datasets or []) == len(MIXED_UPSTREAMS)
+        not_scheduled = pipeline.not_scheduled_datasets
+        assert len(not_scheduled) == 1
+        assert not_scheduled[0].uri == "starbake_stock"
+        assert len(pipeline.scheduled_datasets) == 1
+
+    def test_strategy_does_not_change_datasets(self):
+        """ANY vs ALL only affects combination — never dataset discovery."""
+        uris_any = None
+        uris_all = None
+        for strategy in ("any", "all"):
+            pipeline = self._make_pipeline(TWO_UPSTREAMS, strategy=strategy)
+            with pipeline:
+                pass
+            uris = frozenset(d.uri for d in pipeline.datasets or [])
+            if strategy == "any":
+                uris_any = uris
+            else:
+                uris_all = uris
+        assert uris_any == uris_all == EXPECTED_URIS[TWO_UPSTREAMS]

--- a/tests/shared/triggering_scenarios.py
+++ b/tests/shared/triggering_scenarios.py
@@ -1,0 +1,89 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Shared triggering-strategy scenarios (story: cross-orchestrator
+dataset triggering strategy validation).
+
+Pure-data scenario constants consumed by every orchestrator's
+triggering-strategy tests.  Cross-orchestrator equivalence is
+established transitively: each orchestrator asserts its NATIVE
+triggering artifact against the SAME ``EXPECTED_URIS`` sets — never
+via a single test importing several orchestrator modules (the CI legs
+are dependency-isolated).
+
+Core imports only (NFR13).
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from ai.starlake.orchestration import (
+    StarlakeDependencies,
+    StarlakeDependency,
+    StarlakeDependencyType,
+)
+
+# Each scenario is a tuple of (table_name, cron) upstream pairs.
+# cron=None declares a NOT-scheduled upstream.
+TWO_UPSTREAMS: Tuple[Tuple[str, Optional[str]], ...] = (
+    ("starbake.orders", "0 * * * *"),
+    ("starbake.customers", "0 0 * * *"),
+)
+SINGLE_UPSTREAM: Tuple[Tuple[str, Optional[str]], ...] = (
+    ("starbake.orders", "0 * * * *"),
+)
+NO_UPSTREAM: Tuple[Tuple[str, Optional[str]], ...] = ()
+MIXED_UPSTREAMS: Tuple[Tuple[str, Optional[str]], ...] = (
+    ("starbake.orders", "0 * * * *"),
+    ("starbake.stock", None),
+)
+
+# Cross-orchestrator equivalence anchor (AC #3): every orchestrator's
+# triggering artifact must consume EXACTLY these upstream URIs.
+# uri = sanitize_id(sink).lower() — dots become underscores.
+EXPECTED_URIS = {
+    TWO_UPSTREAMS: frozenset({"starbake_orders", "starbake_customers"}),
+    SINGLE_UPSTREAM: frozenset({"starbake_orders"}),
+    NO_UPSTREAM: frozenset(),
+    MIXED_UPSTREAMS: frozenset({"starbake_orders", "starbake_stock"}),
+}
+
+
+def make_dependencies(
+    upstreams: Tuple[Tuple[str, Optional[str]], ...],
+    task_name: str = "overall_kpis",
+) -> StarlakeDependencies:
+    """Build the StarlakeDependencies for a triggering scenario.
+
+    One first-level TASK dependency whose sub-dependencies (TABLE) are
+    the upstream datasets — the exact shape used by the Epic 1 event
+    combination tests.
+    """
+    return StarlakeDependencies([
+        StarlakeDependency(
+            name=task_name,
+            dependency_type=StarlakeDependencyType.TASK,
+            dependencies=[
+                StarlakeDependency(
+                    name=name,
+                    dependency_type=StarlakeDependencyType.TABLE,
+                    cron=cron,
+                )
+                for name, cron in upstreams
+            ],
+        ),
+    ])

--- a/tests/snowflake/test_snowflake_triggering_strategy.py
+++ b/tests/snowflake/test_snowflake_triggering_strategy.py
@@ -1,0 +1,176 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Snowflake triggering-strategy validation.
+
+Snowflake is ALL-only BY ORCHESTRATOR DESIGN (maintainer-confirmed
+2026-07-14, issue #79): the platform has no event-based triggering
+mechanism, so ``dataset_triggering_strategy`` is never consulted.
+Stream-backed upstreams become a SYSTEM$STREAM_HAS_DATA condition
+(OR across most-frequent scheduled streams, AND across not-scheduled
+streams); non-stream upstreams are checked at runtime by the start
+task with hard-wired ALL semantics (any missing dataset skips the run).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from tests.snowflake.snowflake_test_mixin import SnowflakeTestMixin
+from tests.shared.base_test_triggering_strategy import BaseTestTriggeringStrategy
+from tests.shared.triggering_scenarios import TWO_UPSTREAMS, make_dependencies
+
+
+class TestSnowflakeTriggeringStrategy(SnowflakeTestMixin, BaseTestTriggeringStrategy):
+    """Snowflake concrete implementation of the shared triggering tests."""
+
+
+def _make_stream_dependencies(specs):
+    """Build dependencies whose upstreams are stream-backed.
+
+    specs: iterable of (name, cron, stream) tuples.
+    """
+    from ai.starlake.orchestration import (
+        StarlakeDependencies,
+        StarlakeDependency,
+        StarlakeDependencyType,
+    )
+
+    return StarlakeDependencies([
+        StarlakeDependency(
+            name="overall_kpis",
+            dependency_type=StarlakeDependencyType.TASK,
+            dependencies=[
+                StarlakeDependency(
+                    name=name,
+                    dependency_type=StarlakeDependencyType.TABLE,
+                    cron=cron,
+                    stream=stream,
+                )
+                for name, cron, stream in specs
+            ],
+        ),
+    ])
+
+
+class TestSnowflakeTriggeringStructure(SnowflakeTestMixin):
+    """Structural validation of the SnowflakeDag trigger condition.
+
+    Snowflake has no native ANY/ALL combination: stream-backed upstreams
+    become a SYSTEM$STREAM_HAS_DATA condition (OR across most-frequent
+    scheduled streams, AND across not-scheduled streams) and non-stream
+    upstreams are checked at runtime by the start task with hard-wired
+    ALL semantics (any missing dataset skips the run).
+
+    NFR3 note: ``streams`` / ``not_scheduled_streams`` are Python sets,
+    so the joined condition string order is NON-deterministic — the
+    tests assert per-stream substrings + the connective, never the
+    exact string.
+    """
+
+    def _make_pipeline(self, dependencies, strategy: Optional[str] = None):
+        options = (
+            {"dataset_triggering_strategy": strategy} if strategy else None
+        )
+        orchestration = self.create_orchestration(options=options)
+        pipeline = orchestration.sl_create_pipeline(
+            dependencies=dependencies
+        )
+        with pipeline:
+            pass
+        return pipeline
+
+    def test_non_stream_upstreams_registered_as_datasets(self):
+        """Every non-stream upstream sink is runtime-checked (ALL semantics).
+
+        ``dag.datasets`` keys are DOTTED sinks (``domain.table``) —
+        unlike dataset URIs, which are underscored.
+        """
+        pipeline = self._make_pipeline(make_dependencies(TWO_UPSTREAMS))
+        dag = pipeline.dag
+        assert set(dag.datasets.keys()) == {
+            "starbake.orders",
+            "starbake.customers",
+        }
+        assert dag.condition is None
+        assert not dag.has_streams()
+
+    def test_scheduled_streams_combined_with_or(self):
+        """Most-frequent scheduled streams join with OR.
+
+        Both upstreams share the SAME cron so both are 'most frequent'
+        (a least-frequent stream dataset is audit-checked, not streamed).
+        """
+        pipeline = self._make_pipeline(_make_stream_dependencies([
+            ("starbake.orders", "0 * * * *", "STARBAKE_ORDERS_STREAM"),
+            ("starbake.customers", "0 * * * *", "STARBAKE_CUSTOMERS_STREAM"),
+        ]))
+        condition = pipeline.dag.condition
+        assert condition is not None
+        assert "SYSTEM$STREAM_HAS_DATA('STARBAKE_ORDERS_STREAM')" in condition
+        assert (
+            "SYSTEM$STREAM_HAS_DATA('STARBAKE_CUSTOMERS_STREAM')" in condition
+        )
+        assert " OR " in condition
+        assert " AND " not in condition
+
+    def test_not_scheduled_streams_combined_with_and(self):
+        pipeline = self._make_pipeline(_make_stream_dependencies([
+            ("starbake.orders", None, "STARBAKE_ORDERS_STREAM"),
+            ("starbake.customers", None, "STARBAKE_CUSTOMERS_STREAM"),
+        ]))
+        condition = pipeline.dag.condition
+        assert condition is not None
+        assert "SYSTEM$STREAM_HAS_DATA('STARBAKE_ORDERS_STREAM')" in condition
+        assert (
+            "SYSTEM$STREAM_HAS_DATA('STARBAKE_CUSTOMERS_STREAM')" in condition
+        )
+        assert " AND " in condition
+        assert " OR " not in condition
+
+    def test_mixed_streams_or_group_anded_with_not_scheduled(self):
+        """(scheduled ORs) AND (not-scheduled ANDs) — shape only."""
+        pipeline = self._make_pipeline(_make_stream_dependencies([
+            ("starbake.orders", "0 * * * *", "STARBAKE_ORDERS_STREAM"),
+            ("starbake.stock", None, "STARBAKE_STOCK_STREAM"),
+        ]))
+        condition = pipeline.dag.condition
+        assert condition is not None
+        assert condition.startswith("(")
+        assert ") AND (" in condition
+        assert "SYSTEM$STREAM_HAS_DATA('STARBAKE_ORDERS_STREAM')" in condition
+        assert "SYSTEM$STREAM_HAS_DATA('STARBAKE_STOCK_STREAM')" in condition
+
+    def test_strategy_has_no_structural_effect(self):
+        """PIN (issue #79 — ALL-only by orchestrator design, 2026-07-14):
+        dataset_triggering_strategy is ignored by the Snowflake module —
+        ANY and ALL produce identical DAG structure.
+
+        The runtime dataset check is hard-wired ALL: Snowflake has no
+        event-based triggering mechanism, and the run must ensure all
+        depended-upon datasets were published within the window frame.
+        ANY will NOT be implemented; if that ruling is ever revisited,
+        this pin flips loudly.
+        """
+        p_any = self._make_pipeline(
+            make_dependencies(TWO_UPSTREAMS), strategy="any"
+        )
+        p_all = self._make_pipeline(
+            make_dependencies(TWO_UPSTREAMS), strategy="all"
+        )
+        assert p_any.dag.condition == p_all.dag.condition
+        assert set(p_any.dag.datasets.keys()) == set(p_all.dag.datasets.keys())
+        assert p_any.dag.has_streams() == p_all.dag.has_streams()


### PR DESCRIPTION
Validates that `ALL`/`ANY` dataset triggering strategies produce equivalent behavior across Airflow (2.10.5 and 3.3.0), Dagster and Snowflake — the final layer of the cross-orchestrator pipeline portability epic.

## What's in here

**Shared layer (equivalence anchor)**
- `tests/shared/triggering_scenarios.py` (NEW) — scenario table (`TWO_UPSTREAMS`/`SINGLE_UPSTREAM`/`NO_UPSTREAM`/`MIXED_UPSTREAMS`), `EXPECTED_URIS` frozensets, `make_dependencies()`. Each orchestrator asserts its NATIVE triggering artifact against the same URI sets — transitive equivalence, no cross-importing supertest (CI legs stay dependency-isolated).
- `tests/shared/base_test_triggering_strategy.py` (NEW) — 7 orchestrator-agnostic tests (default-ANY, invalid→silent-ANY pin, event counts, no-upstream `events == []`, mixed scheduled/not-scheduled partitioning, strategy-invariant dataset discovery). Zero new abstract methods.

**Airflow (both majors)**
- `tests/airflow/dataset_compat.py` (NEW) — Dataset/Asset alias block extracted from `test_airflow_runtime.py` (single copy; the new triggering module would otherwise have been copy #2).
- `tests/airflow/test_airflow_runtime.py` — mechanical import-header swap only.
- `tests/airflow/test_airflow_triggering_strategy.py` (NEW) — condition structure on both majors (`DatasetAny`/`AssetAny` for ANY, `DatasetAll`/`AssetAll` for ALL, bare `Dataset`/`Asset` for single upstream, non-dataset timetable for none, two-pipeline strategy divergence) + `evaluate()` truth tables on 2.x only (Airflow 3 removed SDK-side `evaluate()`; documented skip).

**Dagster**
- `tests/dagster/test_dagster_triggering_strategy.py` (NEW) — sensor-tick semantics with runless materializations: ANY/ALL single-upstream trigger, ALL partial skip (gate-level message) / complete trigger, no-upstream → no sensor/schedule, and the behavior pin `test_any_partial_materialization_skips_by_design` for the maintainer-confirmed post-gate consistency check (#78). The pin asserts the POST-gate skip message, so it cannot pass at the gate for the wrong reason.
- **Sensor fix (Closes #80):** the runless and no-datasets-to-check `RunRequest` paths in `starlake_dagster_orchestration.py` never called `context.advance_cursor(asset_events)`; Dagster enforces cursor advancement on every tick that yields runs, so partition-less (runless/external) materializations could never trigger a pipeline — the tick raised `DagsterInvalidDefinitionError`. Red-green proven (3 positive sensor tests failed pre-fix). SkipReason paths deliberately do not advance the cursor.

**Snowflake**
- `tests/snowflake/test_snowflake_triggering_strategy.py` (NEW) — `SYSTEM$STREAM_HAS_DATA` condition shapes (OR across most-frequent scheduled streams, AND across not-scheduled, `(ors) AND (ands)` mixed — substring asserts only, stream sets are unordered), non-stream upstreams registered for the hard-wired-ALL runtime check (dotted-sink keys), and the parity pin `test_strategy_has_no_structural_effect` (#79 — ALL-only by orchestrator design, ANY will not be implemented).

## Test results (fresh CI-equivalent py3.11 venvs, non-editable installs from branch source)

| leg | result |
|---|---|
| orchestration + shared | 114 passed |
| airflow 2.10.5 | 142 passed (124 baseline + 18 new) |
| airflow 3.3.0 | 129 passed + 13 skipped (9 pre-existing + 4 documented `evaluate()` skips) |
| dagster 1.9.13 | 99 passed (85 baseline + 14 new) |
| snowflake | 73 passed + 7 pre-existing xfails (61 baseline + 12 new) |

## Merge note — `tests/airflow/test_airflow_runtime.py` three-way

This PR swaps that file's import header (alias block → `tests.airflow.dataset_compat`). Sibling PR #68 adds a `tests.shared.expected_results` import at the top and rewrites the row-count block; the connection-portability story (3.6) appends a `TestConnectionEndToEnd` class at the end. All three regions are disjoint — merge the import blocks, keep all three changes.

Sibling PRs of the same epic wave: #66 (3.1), #68 (3.3), #73 (3.5), #75 (3.2).

Closes #83
Closes #80
Refs #76, #78, #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)
