### PR TITLE
fix(airflow): default_dag_args precedence — retries/retry_delay options reach tasks (story 6.1)

### DIFF
--- a/starlake-airflow/ARCHITECTURE.md
+++ b/starlake-airflow/ARCHITECTURE.md
@@ -123,10 +123,13 @@ The Airflow-specific base job factory. All execution environment jobs extend thi
 - Parses `end_date` from context var (YYYY-MM-DD format or None)
 - Resolves `max_active_runs` from context var (default: 3)
 
-**`default_dag_args()`** — merges in this order:
+**`default_dag_args()`** — returns a **copy** (the shared `DEFAULT_DAG_ARGS` constant is never mutated — the Airflow scheduler parses many DAG modules in one interpreter, issue #87) built with this precedence (lowest to highest):
+
 1. `DEFAULT_DAG_ARGS` (module constant: depends_on_past=False, start_date=2023-01-01, retries=1, retry_delay=5min, max_active_runs=1)
-2. JSON from `default_dag_args` context var (if present)
-3. `start_date`, `retry_delay`, `retries` from the job instance
+2. JSON from the `default_dag_args` context var (if present)
+3. `start_date` (always framework-derived from the DAG file) and the `retries` / `retry_delay` context vars **only when explicitly provided** — the core fallbacks (retries=1, retry_delay=300s) never clobber a value set via the JSON option
+
+At pipeline level, `AirflowPipeline.__init__` merges `{**job.caller_globals.get('default_dag_args', {}), **job.default_dag_args()}` — the options-derived args win over the caller-module `default_dag_args` snapshot; snapshot-only keys (e.g. `owner`) survive. Hand-written caller modules that need to override an options-derived key can mutate `pipeline.dag.default_args` after `sl_create_pipeline()`, before task construction. The stock orchestrator include computes the module snapshot as `dict(DEFAULT_DAG_ARGS, **__dag_args)`, so the user's `default_dag_args` JSON option wins over the framework constants there too.
 
 **`sl_load()`, `sl_transform()`, `sl_import()`, `sl_pre_load()`** — add Airflow-specific kwargs (`doc`, `pool`, `do_xcom_push`) then delegate to parent. `sl_transform()` additionally appends the runtime `sl_options_from_events` fragment to the transform options (version-aware context key, see *Runtime options propagation*).
 
@@ -408,7 +411,7 @@ The `ts_as_datetime` macro first checks XCom for a `data_interval_end` pushed by
 
 ### 5. Caller Globals Injection
 
-Generated DAG files (from Jinja2 templates) define module-level variables (`description`, `options`, `schedules`, `default_dag_args`, `user_defined_macros`, etc.). The `AirflowPipeline` constructor and `StarlakeAirflowJob` read these via `job.caller_globals` — this is how template-generated configuration flows into the pipeline without modifying framework code.
+Generated DAG files (from Jinja2 templates) define module-level variables (`description`, `options`, `schedules`, `default_dag_args`, `user_defined_macros`, etc.). The `AirflowPipeline` constructor and `StarlakeAirflowJob` read these via `job.caller_globals` — this is how template-generated configuration flows into the pipeline without modifying framework code. Note that for `default_dag_args` specifically, the options-derived dict returned by `job.default_dag_args()` takes precedence over the caller-module snapshot (issue #87); snapshot-only keys survive.
 
 ## Module Constants
 

--- a/starlake-airflow/pom.xml
+++ b/starlake-airflow/pom.xml
@@ -14,7 +14,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>starlake-airflow</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2</version>
     <packaging>jar</packaging>
 
 </project>

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_job.py
@@ -763,12 +763,29 @@ class StarlakeAirflowJob(IStarlakeJob[BaseOperator, Dataset], StarlakeAirflowOpt
     def default_dag_args(self) -> dict:
         import json
         from json.decoder import JSONDecodeError
-        dag_args = DEFAULT_DAG_ARGS
+        # Precedence contract (issue #87):
+        #   DEFAULT_DAG_ARGS (framework constants)
+        #     < default_dag_args JSON option
+        #     < explicitly provided retries / retry_delay options
+        # start_date is always framework-derived (computed from the DAG file).
+        # copy: the shared module constant must never be mutated — the Airflow
+        # scheduler parses many DAG modules in one interpreter.
+        dag_args = dict(DEFAULT_DAG_ARGS)
         try:
             dag_args.update(json.loads(__class__.get_context_var(var_name="default_dag_args", options=self.options)))
         except (MissingEnvironmentVariable, JSONDecodeError):
             pass
-        dag_args.update({'start_date': self.start_date, 'retry_delay': timedelta(seconds=self.retry_delay), 'retries': self.retries})
+        dag_args.update({'start_date': self.start_date})
+        # only an explicitly provided option may override the JSON option —
+        # the core fallbacks (retries=1, retry_delay=300) must not clobber it
+        try:
+            dag_args.update({'retries': int(__class__.get_context_var(var_name='retries', options=self.options))})
+        except (MissingEnvironmentVariable, ValueError):
+            pass
+        try:
+            dag_args.update({'retry_delay': timedelta(seconds=int(__class__.get_context_var(var_name='retry_delay', options=self.options)))})
+        except (MissingEnvironmentVariable, ValueError):
+            pass
         return dag_args
 
 import jinja2

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_orchestration.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_orchestration.py
@@ -66,9 +66,12 @@ class AirflowPipeline(AbstractPipeline[DAG, BaseOperator, TaskGroup, Dataset], A
         j: StarlakeAirflowJob = job
         max_active_runs: int = j.max_active_runs
 
+        # options-derived args (retries, retry_delay, start_date and the
+        # default_dag_args JSON option) win over the caller-module snapshot;
+        # snapshot-only keys (e.g. 'owner') survive (issue #87)
         default_args = {
-            **job.default_dag_args(), 
-            **job.caller_globals.get('default_dag_args', {})
+            **job.caller_globals.get('default_dag_args', {}),
+            **job.default_dag_args()
         }
 
         # AssetOrTimeSchedule is not supported yet within SL

--- a/starlake-airflow/src/main/python/setup.py
+++ b/starlake-airflow/src/main/python/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 import os
 
-version = os.environ.get("PROJECT_VERSION", "0.6.1")
+version = os.environ.get("PROJECT_VERSION", "0.6.2")
 
 setup(name='starlake-airflow',
       version=version,

--- a/starlake-airflow/src/main/resources/templates/dags/__starlake_airflow_orchestrator.py.j2
+++ b/starlake-airflow/src/main/resources/templates/dags/__starlake_airflow_orchestrator.py.j2
@@ -8,4 +8,4 @@ from ai.starlake.airflow import StarlakeAirflowOptions, DEFAULT_DAG_ARGS
 import json
 
 __dag_args = json.loads(StarlakeAirflowOptions.get_context_var(var_name="default_dag_args", default_value="""{}""", options=options))
-default_dag_args = dict(__dag_args, **DEFAULT_DAG_ARGS)
+default_dag_args = dict(DEFAULT_DAG_ARGS, **__dag_args)

--- a/tests/airflow/test_airflow_dag_args_precedence.py
+++ b/tests/airflow/test_airflow_dag_args_precedence.py
@@ -1,0 +1,209 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Story 6.1 (issue #87) — default_dag_args precedence.
+
+The ``retries`` / ``retry_delay`` dag-generation options (and the
+``default_dag_args`` JSON option) must reach every task of the generated DAG:
+
+1. ``StarlakeAirflowJob.default_dag_args()`` must not mutate the shared
+   ``DEFAULT_DAG_ARGS`` module constant (AC3).
+2. At pipeline level, the options-derived args win over the caller-module
+   ``default_dag_args`` snapshot (AC1) while snapshot-only keys survive (AC4).
+3. The orchestrator include computes the module snapshot with the user's
+   JSON option winning over the framework constants (AC2).
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from datetime import timedelta
+
+import pytest
+
+from ai.starlake.airflow import DEFAULT_DAG_ARGS
+from ai.starlake.airflow.bash import StarlakeAirflowBashJob
+
+from tests.airflow.conftest import _AIRFLOW_TEST_MODULE_NAME
+
+
+def _make_job(options: dict) -> StarlakeAirflowBashJob:
+    return StarlakeAirflowBashJob(
+        filename="test_dag_args_precedence.py",
+        module_name=_AIRFLOW_TEST_MODULE_NAME,
+        options=options,
+    )
+
+
+def _inject_caller_snapshot(monkeypatch, snapshot: dict) -> None:
+    """Set a module-level ``default_dag_args`` snapshot on the fake caller
+    module, the way template-generated DAG modules do.  monkeypatch restores
+    (removes) the attribute on teardown so sibling tests are unaffected."""
+    caller = sys.modules[_AIRFLOW_TEST_MODULE_NAME]
+    monkeypatch.setattr(caller, "default_dag_args", snapshot, raising=False)
+
+
+# ------------------------------------------------------------------
+# AC3 — default_dag_args() must not mutate DEFAULT_DAG_ARGS
+# ------------------------------------------------------------------
+
+class TestDefaultDagArgsNoSharedMutation:
+
+    def test_default_dag_args_leaves_module_constant_unchanged(self):
+        """Calling default_dag_args() with retries/retry_delay options returns
+        the options-derived values WITHOUT polluting the shared constant —
+        the Airflow scheduler parses many DAG modules in one interpreter, so
+        a mutated constant bleeds across DAGs."""
+        before = copy.deepcopy(DEFAULT_DAG_ARGS)
+
+        job = _make_job({"retries": "0", "retry_delay": "10"})
+        dag_args = job.default_dag_args()
+
+        assert dag_args["retries"] == 0
+        assert dag_args["retry_delay"] == timedelta(seconds=10)
+        # the shared constant is untouched — exact values, not just keys
+        assert DEFAULT_DAG_ARGS == before
+        assert DEFAULT_DAG_ARGS["retries"] == 1
+        assert DEFAULT_DAG_ARGS["retry_delay"] == timedelta(minutes=5)
+
+    def test_default_dag_args_json_option_does_not_leak_into_constant(self):
+        """The default_dag_args JSON option is folded into the returned dict
+        only — a key absent from DEFAULT_DAG_ARGS must not appear in the
+        constant after the call."""
+        before = copy.deepcopy(DEFAULT_DAG_ARGS)
+
+        job = _make_job({"default_dag_args": json.dumps({"owner": "data-team"})})
+        dag_args = job.default_dag_args()
+
+        assert dag_args["owner"] == "data-team"
+        assert "owner" not in DEFAULT_DAG_ARGS
+        assert DEFAULT_DAG_ARGS == before
+
+
+# ------------------------------------------------------------------
+# Job-level precedence ladder inside default_dag_args()
+# ------------------------------------------------------------------
+
+class TestJobLevelPrecedenceLadder:
+
+    def test_explicit_options_win_over_json_option(self):
+        """Explicitly provided retries/retry_delay options rank above the
+        default_dag_args JSON option."""
+        job = _make_job({
+            "default_dag_args": json.dumps({"retries": 5, "retry_delay": 60}),
+            "retries": "0",
+            "retry_delay": "10",
+        })
+        dag_args = job.default_dag_args()
+
+        assert dag_args["retries"] == 0
+        assert dag_args["retry_delay"] == timedelta(seconds=10)
+
+    def test_json_option_wins_over_core_fallbacks_when_options_absent(self):
+        """Without explicit retries/retry_delay options, the JSON option value
+        stands — the core fallbacks (retries=1, retry_delay=300) must not
+        clobber it (the exact '{"retries": 0}' repro from issue #87)."""
+        job = _make_job({"default_dag_args": json.dumps({"retries": 0})})
+        dag_args = job.default_dag_args()
+
+        assert dag_args["retries"] == 0
+        # untouched framework constant fills the non-overlapping key
+        assert dag_args["retry_delay"] == timedelta(minutes=5)
+
+
+# ------------------------------------------------------------------
+# AC1 / AC4 — pipeline-level precedence
+# ------------------------------------------------------------------
+
+class TestPipelineDagArgsPrecedence:
+
+    def _create_pipeline(self, options: dict):
+        from ai.starlake.airflow import AirflowOrchestration
+        from ai.starlake.orchestration import StarlakeSchedule
+
+        orch = AirflowOrchestration(job=_make_job(options))
+        schedule = StarlakeSchedule(name=None, cron="0 0 * * *", domains=[])
+        return orch.sl_create_pipeline(schedule=schedule)
+
+    def test_options_win_over_legacy_caller_snapshot(self, monkeypatch):
+        """AC1 — a caller module carrying the legacy snapshot
+        ``dict(__dag_args, **DEFAULT_DAG_ARGS)`` (retries=1, retry_delay=5min)
+        no longer overrides the options-derived args: retries=0/retry_delay=10
+        from the job options land in dag.default_args AND on the tasks."""
+        legacy_snapshot = dict({}, **DEFAULT_DAG_ARGS)  # constants win — old include line
+        assert legacy_snapshot["retries"] == 1  # guard: snapshot really carries the default
+        _inject_caller_snapshot(monkeypatch, legacy_snapshot)
+
+        pipeline = self._create_pipeline({"retries": "0", "retry_delay": "10"})
+
+        assert pipeline.dag.default_args["retries"] == 0
+        assert pipeline.dag.default_args["retry_delay"] == timedelta(seconds=10)
+
+        # task-level proof: default_args apply at operator construction on
+        # both Airflow majors
+        with pipeline:
+            load_task = pipeline.sl_load(
+                task_id="load_starbake_customers",
+                domain="starbake",
+                table="customers",
+            )
+        assert load_task is not None
+        assert load_task.task.retries == 0
+        assert load_task.task.retry_delay == timedelta(seconds=10)
+
+    def test_default_dag_args_json_option_reaches_dag(self, monkeypatch):
+        """AC1 — an explicit ``default_dag_args`` JSON option wins over the
+        legacy caller snapshot too."""
+        _inject_caller_snapshot(monkeypatch, dict({}, **DEFAULT_DAG_ARGS))
+
+        pipeline = self._create_pipeline(
+            {"default_dag_args": json.dumps({"retries": 0})}
+        )
+
+        assert pipeline.dag.default_args["retries"] == 0
+
+    def test_snapshot_only_key_survives(self, monkeypatch):
+        """AC4 — a caller-snapshot key that default_dag_args() does not emit
+        (e.g. 'owner') still reaches dag.default_args after the flip."""
+        _inject_caller_snapshot(monkeypatch, {"owner": "data-team"})
+
+        pipeline = self._create_pipeline({"retries": "0"})
+
+        assert pipeline.dag.default_args["owner"] == "data-team"
+        assert pipeline.dag.default_args["retries"] == 0
+
+
+# ------------------------------------------------------------------
+# AC2 — include-level snapshot semantics
+# ------------------------------------------------------------------
+
+class TestIncludeSnapshotSemantics:
+
+    def test_user_json_option_wins_over_framework_constants(self):
+        """AC2 — the new include expression ``dict(DEFAULT_DAG_ARGS,
+        **__dag_args)`` lets the user's default_dag_args JSON option win over
+        the framework constants in the module snapshot."""
+        __dag_args = json.loads('{"retries": 0}')
+        snapshot = dict(DEFAULT_DAG_ARGS, **__dag_args)
+
+        assert snapshot["retries"] == 0
+        # non-overlapping framework keys are preserved
+        assert snapshot["retry_delay"] == timedelta(minutes=5)
+        assert snapshot["depends_on_past"] is False
+        # building the snapshot must not mutate the constant
+        assert DEFAULT_DAG_ARGS["retries"] == 1

--- a/tests/airflow/test_airflow_templates.py
+++ b/tests/airflow/test_airflow_templates.py
@@ -102,7 +102,9 @@ class TestAirflowTemplateComposition:
         # __starlake_airflow_orchestrator.py.j2 — enum + airflow-specific vars
         assert "orchestrator = StarlakeOrchestrator.AIRFLOW" in rendered
         assert "access_control = None" in rendered
-        assert "default_dag_args = dict(__dag_args, **DEFAULT_DAG_ARGS)" in rendered
+        # story 6.1 (issue #87): the user's default_dag_args JSON option wins
+        # over the framework constants in the module snapshot
+        assert "default_dag_args = dict(DEFAULT_DAG_ARGS, **__dag_args)" in rendered
         # __starlake_shell_execution.py — execution environment
         assert "execution_environment = StarlakeExecutionEnvironment.SHELL" in rendered
         # __common__.py.j2 — config projection


### PR DESCRIPTION
Closes #87

## Problem

Three dicts merged in the wrong order, so the `retries`/`retry_delay` dag-generation options (and the `default_dag_args` JSON option) never reached the tasks of a generated DAG — every task silently kept the framework defaults (`retries=1`, `retry_delay=5min`). Worse, `default_dag_args()` mutated the shared `DEFAULT_DAG_ARGS` module constant, bleeding options across every DAG module parsed in the same scheduler interpreter.

## Three-point fix (starlake-airflow only, 0.6.1 → 0.6.2)

1. **`StarlakeAirflowJob.default_dag_args()`** starts from a copy (`dict(DEFAULT_DAG_ARGS)`) — the shared constant is never mutated. It also now folds `retries`/`retry_delay` in **only when explicitly provided**: the core fallbacks (retries=1, retry_delay=300s, applied when the options are absent) no longer clobber a value set via the `default_dag_args` JSON option — the exact `'{"retries": 0}'` repro from #87 now works end-to-end.
2. **`AirflowPipeline.__init__`** merge flipped: `{**caller_globals.get('default_dag_args', {}), **job.default_dag_args()}` — options-derived args win over the caller-module snapshot; snapshot-only keys (e.g. `owner`) survive. This makes runtime behavior correct for **every already-generated DAG module**, regardless of template vintage (the pinned CLI 1.5.11 still bundles the old include).
3. **Orchestrator include** snapshot flipped to `dict(DEFAULT_DAG_ARGS, **__dag_args)` so the user's JSON option wins over the framework constants in future CLI releases.

Resulting precedence contract (documented in `starlake-airflow/ARCHITECTURE.md`):

```
DEFAULT_DAG_ARGS < default_dag_args JSON option < explicit retries/retry_delay options
```

`start_date` stays framework-derived (computed from the DAG file).

## ⚠️ Known behavioral change

Hand-written caller modules that set a module-level `default_dag_args` snapshot **directly** (not via the `default_dag_args` JSON option) previously overrode everything. After this flip, keys that `job.default_dag_args()` emits (the 7 `DEFAULT_DAG_ARGS` keys + JSON-option keys + `start_date`, and explicitly-set `retries`/`retry_delay`) win over such snapshots; snapshot-only keys still apply. Workaround for modules that need to override an options-derived key: mutate `pipeline.dag.default_args` after `sl_create_pipeline()`, before task construction (documented in ARCHITECTURE.md). The README's hand-written example DAGs pass `default_args` to `DAG(...)` directly and are unaffected.

## Tests

- New `tests/airflow/test_airflow_dag_args_precedence.py` (8 tests): constant-mutation guards, job-level precedence ladder (both directions), pipeline-level precedence with a legacy caller snapshot incl. task-level proof (`task.retries == 0` on a `pipeline.sl_load()` task), snapshot-only-key survival, include-snapshot semantics.
- Flipped the pinned template assertion in `tests/airflow/test_airflow_templates.py`.
- Full `tests/airflow` suite run locally on **both majors** against worktree source (non-editable installs): Airflow 2.10.5 → 204 passed; Airflow 3.3.0 → 191 passed + 13 documented v3 skips.

CI path filter: only `starlake-airflow/**` + `tests/airflow/**` touched → airflow legs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)