### PR TITLE
Fix StarlakeDependencies dependency lookup

### DIFF
--- a/starlake-orchestration/src/main/python/ai/starlake/orchestration/starlake_dependencies.py
+++ b/starlake-orchestration/src/main/python/ai/starlake/orchestration/starlake_dependencies.py
@@ -365,6 +365,10 @@ class StarlakeDependencies():
                 if parent.id not in all_nodes.keys():
                     all_nodes[parent.id] = parent
 
+        self.__dependencies_map = {
+            dependency.name: dependency for dependency in self.dependencies
+        }
+        self.__dependencies_map.update(all_dependencies)
         self.__all_dependencies = all_dependencies
         self.__first_level_tasks = first_level_tasks
         self.__filtered_datasets = filtered_datasets

--- a/starlake-orchestration/src/main/python/ai/starlake/orchestration/starlake_dependencies.py
+++ b/starlake-orchestration/src/main/python/ai/starlake/orchestration/starlake_dependencies.py
@@ -365,10 +365,10 @@ class StarlakeDependencies():
                 if parent.id not in all_nodes.keys():
                     all_nodes[parent.id] = parent
 
-        self.__dependencies_map = {
-            dependency.name: dependency for dependency in self.dependencies
-        }
-        self.__dependencies_map.update(all_dependencies)
+        self.__dependencies_map = dict(all_dependencies)
+        self.__dependencies_map.update(
+            {dependency.name: dependency for dependency in self.dependencies}
+        )
         self.__all_dependencies = all_dependencies
         self.__first_level_tasks = first_level_tasks
         self.__filtered_datasets = filtered_datasets

--- a/tests/orchestration/test_cron_scheduling.py
+++ b/tests/orchestration/test_cron_scheduling.py
@@ -283,6 +283,44 @@ class TestStarlakeDependenciesFromJson:
         assert deps.get_dependency("child.table") is parent.dependencies[0]
         assert deps.get_dependency("missing") is None
 
+    def test_diamond_name_collision_first_level_wins(self):
+        # Diamond shape: "shared.table" appears both as a first-level
+        # dependency and nested as a child of another first-level task.
+        # get_dependency must return the first-level instance.
+        json_str = json.dumps([
+            {
+                "data": {
+                    "name": "shared.table",
+                    "typ": "table",
+                    "cron": "0 0 * * *",
+                },
+                "children": [],
+            },
+            {
+                "data": {
+                    "name": "consumer_task",
+                    "typ": "task",
+                },
+                "children": [
+                    {
+                        "data": {
+                            "name": "shared.table",
+                            "typ": "table",
+                            "cron": "0 0 * * *",
+                        },
+                        "children": [],
+                    }
+                ],
+            },
+        ])
+        deps = StarlakeDependencies(json_str)
+        first_level = deps.dependencies[0]
+        nested = deps.dependencies[1].dependencies[0]
+        assert first_level.name == "shared.table"
+        assert nested.name == "shared.table"
+        assert first_level is not nested
+        assert deps.get_dependency("shared.table") is first_level
+
 
 # ---------------------------------------------------------------------------
 # 4.10  StarlakeDependency.computed_cron

--- a/tests/orchestration/test_cron_scheduling.py
+++ b/tests/orchestration/test_cron_scheduling.py
@@ -279,6 +279,9 @@ class TestStarlakeDependenciesFromJson:
         assert parent.dependency_type == StarlakeDependencyType.TASK
         assert len(parent.dependencies) == 1
         assert parent.dependencies[0].name == "child.table"
+        assert deps.get_dependency("parent_task") is parent
+        assert deps.get_dependency("child.table") is parent.dependencies[0]
+        assert deps.get_dependency("missing") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`StarlakeDependencies.get_dependency()` always raised `AttributeError` because its lookup map was never initialized. Build the map from top-level and nested dependencies, and extend the existing hierarchy test to cover successful and missing-name lookups.

Refs #65