### PR TITLE
fix(airflow): cloud engines must fail the task chain on a failed job (preload excepted) — closes #92

### DIFF
--- a/starlake-airflow/ARCHITECTURE.md
+++ b/starlake-airflow/ARCHITECTURE.md
@@ -329,6 +329,18 @@ Wraps Airflow's native `TaskGroup`. The context manager calls `self.group.__ente
 
 Each concrete job implements `sl_execution_environment()` and `sl_job()`:
 
+#### Cloud engine failure propagation (story 6.3, issue #92)
+
+Contract: **a failed Starlake job fails the Airflow task chain for every task type except PRELOAD**, under default options, on every cloud engine/mode. PRELOAD is the one task type designed around swallowing — its failure surfaces as a falsy `return_value` XCom that the `skip_or_start` `ShortCircuitOperator` turns into a downstream skip.
+
+Swallow-vs-propagate is keyed on `preload = task_type == TaskType.PRELOAD`, computed in each cloud `sl_job()` and threaded to operators/sensors as an explicit `preload` ctor flag — never on `do_xcom_push` (defaults to `True` on `BaseOperator`, and forced `True` for structural XCom plumbing) nor on `retry_on_failure` alone. Three provider-free seams on `StarlakeAirflowJob` pin the contract in CI (which installs no google/amazon providers):
+
+- `_sl_xcom_wrapped_command(command, preload)` — the echo/XCom bash wrapper; the preload variant swallows the exit code, the non-preload variant keeps the active `exit $return_code` trailer. Used by the bash job and both cloud_run gcloud paths (the async `_get_completion_status` task previously shipped the exit block commented out — a failed execution ended the chain green).
+- `_sl_cloud_failure_swallowed(preload, retry_on_failure)` — `True` only for preload with `retry_on_failure=false`; `retry_on_failure=true` re-raises even for preload (the #91 retries-as-poke workaround).
+- `_sl_cloud_poke_failure(preload, message)` — completion-sensor failure verdict: `PokeReturnValue(True, False)` for preload (`PokeReturnValue` truthiness is `is_done`, so returning it COMPLETES the sensor — the swallow), `AirflowException` otherwise. Used by `FargateTaskStateSensor.poke()` and `CloudRunJobCompletionSensor.poke()`.
+
+Sensors never get the exit-swallowing wrapper: a `BashSensor`'s protocol needs the true exit code (0=done, `retry_exit_code`=poke again, other=fail) — the `GCloudRunJobCompletionSensor` `retry_on_failure` wrapper (which always exited 0) was removed.
+
 #### `StarlakeAirflowBashJob` — Shell Execution
 
 **`sl_execution_environment()`** → `StarlakeExecutionEnvironment.SHELL`
@@ -338,7 +350,7 @@ Each concrete job implements `sl_execution_environment()` and `sl_job()`:
 2. For LOAD/TRANSFORM tasks: prepends `--scheduledDate` with a Jinja2 template to the arguments
 3. Merges `sl_env_vars` into the `--options` argument: if `--options` already exists in arguments, parses existing key=value pairs, merges with sl_env_vars, and rewrites. If not present, appends `--options` with all sl_env_vars. The value is **double-quoted** so env var values containing spaces survive `bash -c` word splitting (issue #49; double quotes because the `do_xcom_push` wrapper nests the command in single-quoted `bash -c`).
 4. Builds the command: `{SL_STARLAKE_PATH} {arguments}` (SL_STARLAKE_PATH defaults to "starlake")
-5. If `do_xcom_push=True`: wraps in `bash -c` with return code capture (`echo $return_code`). For PRELOAD tasks, does NOT `exit $return_code` on non-zero — the return code signals skip/proceed to `skip_or_start_op()`.
+5. If `do_xcom_push=True`: wraps via the shared `StarlakeAirflowJob._sl_xcom_wrapped_command(command, preload)` builder (story 6.3) — `bash -c` with return code capture (`echo $return_code`). For PRELOAD tasks the wrapper does NOT `exit $return_code` on non-zero — the return code signals skip/proceed to `skip_or_start_op()`; for every other task type the active `exit $return_code` trailer fails the task.
 6. Returns `StarlakeBashOperator` with `cwd=self.sl_root` and merged env vars
 
 #### `StarlakeAirflowCloudRunJob` — GCP Cloud Run Execution
@@ -389,9 +401,9 @@ Note: Dataproc is sync-only (the code explicitly pops `asynchronous` kwarg with 
 3. If sync (`wait_for_completion=True`): returns `FargateTaskOperator`
 4. If async: returns `TaskGroup` with `FargateTaskOperator(wait_for_completion=False)` >> `FargateTaskStateSensor`
 
-**`FargateTaskOperator.execute()`** — wraps `EcsRunTaskOperator.execute()`. Returns `True` on success (sync) or `None` (async). On exception, pushes `False` to XCom if `do_xcom_push=True`.
+**`FargateTaskOperator.execute()`** — wraps `EcsRunTaskOperator.execute()`. Returns `True` on success (sync) or `None` (async). On exception: re-raises for every task type except PRELOAD (story 6.3); a failed preload with `retry_on_failure=false` returns `False` (recorded as the `return_value` XCom via `do_xcom_push`, forced by `sl_pre_load` — returning it instead of an explicit `xcom_push` call keeps both Airflow majors happy), and `retry_on_failure=true` re-raises even for preload.
 
-**`FargateTaskStateSensor.poke()`** — polls ECS via `describe_tasks`, checks `lastStatus` and container `exitCode`. Returns `PokeReturnValue(True, True)` on success (exit code 0), `PokeReturnValue(True, False)` on failure.
+**`FargateTaskStateSensor.poke()`** — polls ECS via `describe_tasks`, checks `lastStatus` and container `exitCode`. Returns `PokeReturnValue(True, True)` on success (exit code 0); on failure the verdict comes from `_sl_cloud_poke_failure` (preload → sensor completes with a falsy XCom; anything else → `AirflowException`).
 
 ## Key Architectural Patterns
 

--- a/starlake-airflow/README.md
+++ b/starlake-airflow/README.md
@@ -819,7 +819,7 @@ Additional options may be specified to configure the **Cloud Run job**.
 | **cloud_run_service_account** | str   | the optional cloud run service account                                                                    |
 | **cloud_run_async**           | bool  | the optional flag to run the cloud run job asynchronously (`True` by default)                           |
 | **cloud_run_async_poke_interval** | float | the optional poke interval for async sensor in seconds (`30` by default)                            |
-| **retry_on_failure**          | bool  | the optional flag to retry the cloud run job on failure (`False` by default)                            |
+| **retry_on_failure**          | bool  | the optional flag governing the **pre-load** task on failure (`False` by default): `false` swallows a failed preload (the `skip_or_start` XCom gating skips downstream loads), `true` fails the task so `retries` re-run it (retries-as-poke); in async gcloud mode it also switches the completion topology (sensor with `retry_exit_code` instead of the status task). Since 0.6.4 (issue #92) a failed **load/transform/stage** job always fails the task, whatever this flag |
 | **retry_delay_in_seconds**    | float | the optional delay in seconds to wait before retrying the cloud run job (`10` by default)               |
 | **use_gcloud**                | bool  | whether to use the gcloud command or the google cloud run python operator (`True` by default)           |
 
@@ -915,7 +915,7 @@ Additional options may be specified to configure the **Fargate job**.
 | **memory**                           | int   | the optional container memory in MiB (`2048` by default)                                      |
 | **fargate_async**                    | bool  | the optional flag to run asynchronously (`True` by default)                                   |
 | **fargate_async_poke_interval**      | float | the optional poke interval for async sensor in seconds (`30` by default)                      |
-| **retry_on_failure**                 | bool  | the optional flag to retry on failure (`False` by default)                                    |
+| **retry_on_failure**                 | bool  | the optional flag governing the **pre-load** task on failure (`False` by default): `false` swallows a failed preload (its `False` XCom lets `skip_or_start` skip downstream loads), `true` fails the task so `retries` re-run it (retries-as-poke, sync mode only). Since 0.6.4 (issue #92) a failed **load/transform/stage** job always fails the task, whatever this flag |
 
 #### StarlakeAirflowFargateJob load Example
 

--- a/starlake-airflow/pom.xml
+++ b/starlake-airflow/pom.xml
@@ -14,7 +14,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>starlake-airflow</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <packaging>jar</packaging>
 
 </project>

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/aws/starlake_airflow_fargate_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/aws/starlake_airflow_fargate_job.py
@@ -56,6 +56,10 @@ class StarlakeAirflowFargateJob(StarlakeAirflowJob):
         """
         # story 6.2 — sensor mode is shell-only: pop the kwargs and fail fast
         self.__class__._reject_pre_load_sensor_kwargs(kwargs, 'fargate')
+        # story 6.3 (issue #92) — PRELOAD is the only task type whose failure
+        # is swallowed (XCom-gated via skip_or_start); every other task type
+        # must fail the chain on a failed job
+        preload = task_type == TaskType.PRELOAD
         # explicit --scheduledDate override — popped unconditionally: BaseOperator
         # would reject the kwarg
         scheduled_date = kwargs.pop('scheduled_date', None)
@@ -110,6 +114,7 @@ class StarlakeAirflowFargateJob(StarlakeAirflowJob):
                 network_configuration=network_configuration,
                 wait_for_completion=True,
                 retry_on_failure=self.retry_on_failure,
+                preload=preload,
                 **kwargs
             )
         else:
@@ -126,6 +131,7 @@ class StarlakeAirflowFargateJob(StarlakeAirflowJob):
                     launch_type="FARGATE",
                     network_configuration=network_configuration,
                     wait_for_completion=False,
+                    preload=preload,
                     **kwargs
                 )
                 check_completion_id = task_id + '_check_completion'
@@ -137,6 +143,7 @@ class StarlakeAirflowFargateJob(StarlakeAirflowJob):
                     task=run_task.output["ecs_task_arn"],
                     poke_interval=self.fargate_async_poke_interval,
                     pool=kwargs.get('pool', self.pool),
+                    preload=preload,
                 )
                 run_task >> completion_sensor
             return task_completion_sensors
@@ -165,6 +172,7 @@ class FargateTaskOperator(StarlakeDatasetMixin, EcsRunTaskOperator):
         network_configuration: Optional[Dict[str, Any]] = None,
         wait_for_completion: bool = True,
         retry_on_failure: bool = False,
+        preload: bool = False,
         **kwargs
     ) -> None:
         super().__init__(
@@ -182,6 +190,7 @@ class FargateTaskOperator(StarlakeDatasetMixin, EcsRunTaskOperator):
             **kwargs
         )
         self.retry_on_failure = retry_on_failure
+        self.preload = preload
 
     def execute(self, context):
         logger = logging.getLogger(__name__)
@@ -194,10 +203,19 @@ class FargateTaskOperator(StarlakeDatasetMixin, EcsRunTaskOperator):
                 return None
         except Exception as e:
             logger.exception(msg = f"Task {self.task_id} has failed")
-            if self.wait_for_completion and self.do_xcom_push:
-                self.xcom_push(context, key="return_value", value=False)
-            if self.retry_on_failure:
+            # story 6.3 (issue #92) — single verdict source: only preload with
+            # retry_on_failure=false swallows (a failed load/transform/stage
+            # always fails the task; retry_on_failure=true re-raises even for
+            # preload, the retries-as-poke workaround of #91)
+            if not StarlakeAirflowJob._sl_cloud_failure_swallowed(self.preload, self.retry_on_failure):
                 raise e
+            if self.wait_for_completion:
+                # False becomes the return_value XCom (do_xcom_push is forced
+                # by sl_pre_load) so skip_or_start skips downstream; returning
+                # it — instead of the previous explicit self.xcom_push — works
+                # on both majors (Airflow 3 operators have no xcom_push)
+                return False
+            return None
 
 class FargateTaskStateSensor(StarlakeDatasetMixin, EcsTaskStateSensor):
     """
@@ -210,6 +228,7 @@ class FargateTaskStateSensor(StarlakeDatasetMixin, EcsTaskStateSensor):
         source: Optional[str],
         cluster: str,
         task: str,
+        preload: bool = False,
         **kwargs
     ) -> None:
         super().__init__(
@@ -222,32 +241,39 @@ class FargateTaskStateSensor(StarlakeDatasetMixin, EcsTaskStateSensor):
             failure_states={EcsTaskStates.NONE},
             **kwargs
         )
+        self.preload = preload
 
     def poke(self, context):
+        # story 6.3 (issue #92) — completing the sensor with a falsy XCom
+        # (PokeReturnValue truthiness is is_done) is correct gating for
+        # preload but a silent success for every other task type: the failure
+        # verdict is keyed on the task type via _sl_cloud_poke_failure. The
+        # verdict is emitted OUTSIDE the try block so an AirflowException
+        # raised by the hook itself cannot bypass the preload swallow.
         logger = logging.getLogger(__name__)
         logger.info(f"Checking task {self.task} state")
+        failure_message = None
         try:
             tasks = self.hook.conn.describe_tasks(cluster=self.cluster, tasks=[self.task]).get("tasks", [])
-            if tasks:
-                task = tasks[0]
-                status: str = task.get("lastStatus", None)
-                if status:
-                    logger.info(f"Task {self.task} state: {status}")
-                    if EcsTaskStates(status) in self.failure_states:
-                        logger.error(msg = f"Task {self.task} has failed with status {status}")
-                        return PokeReturnValue(True, False)
-                    elif EcsTaskStates(status) == self.target_state:
-                        containers = task.get("containers", [])
-                        if containers and containers[0].get("exitCode", 1) == 0:
-                            logger.info(f"Task {self.task} has succeeded")
-                            return PokeReturnValue(True, True)
-                        else:
-                            logger.error(msg = f"Task {self.task} has failed")
-                            return PokeReturnValue(True, False)
+            if not tasks:
+                return None
+            task = tasks[0]
+            status: str = task.get("lastStatus", None)
+            if not status:
+                failure_message = f"Task {self.task} has failed with no status"
+            else:
+                logger.info(f"Task {self.task} state: {status}")
+                if EcsTaskStates(status) in self.failure_states:
+                    failure_message = f"Task {self.task} has failed with status {status}"
+                elif EcsTaskStates(status) == self.target_state:
+                    containers = task.get("containers", [])
+                    if containers and containers[0].get("exitCode", 1) == 0:
+                        logger.info(f"Task {self.task} has succeeded")
+                        return PokeReturnValue(True, True)
+                    failure_message = f"Task {self.task} has failed"
                 else:
-                    logger.error(msg = f"Task {self.task} has failed with no status")
-                    return PokeReturnValue(True, False)
-            return None
+                    return None
         except Exception as e:
-            logger.error(msg = f"Task {self.task} has failed")
-            return PokeReturnValue(True, False)
+            failure_message = f"Task {self.task} has failed: {e}"
+        logger.error(msg = failure_message)
+        return StarlakeAirflowJob._sl_cloud_poke_failure(self.preload, failure_message)

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/bash/starlake_airflow_bash_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/bash/starlake_airflow_bash_job.py
@@ -173,34 +173,10 @@ class StarlakeAirflowBashJob(StarlakeAirflowJob):
             )
 
         if kwargs.get('do_xcom_push', False):
-            if preload:
-                command=f"""
-                set -e
-                bash -c '
-                {command}
-                return_code=$?
-
-                # Push the return code to XCom
-                echo $return_code
-
-                '
-                """
-            else:
-                command=f"""
-                set -e
-                bash -c '
-                {command}
-                return_code=$?
-
-                # Push the return code to XCom
-                echo $return_code
-
-                # Exit with the captured return code if non-zero
-                if [ $return_code -ne 0 ]; then
-                    exit $return_code
-                fi
-                '
-                """
+            # story 6.3 (issue #92) — shared wrapper builder: preload swallows
+            # the exit code (XCom-gated via skip_or_start), every other task
+            # type keeps the active `exit $return_code` trailer
+            command = self.__class__._sl_xcom_wrapped_command(command, preload)
         return StarlakeBashOperator(
             task_id=task_id,
             dataset=dataset,

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/gcp/starlake_airflow_cloud_run_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/gcp/starlake_airflow_cloud_run_job.py
@@ -112,6 +112,10 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
         """
         # story 6.2 — sensor mode is shell-only: pop the kwargs and fail fast
         self.__class__._reject_pre_load_sensor_kwargs(kwargs, 'cloud_run')
+        # story 6.3 (issue #92) — PRELOAD is the only task type whose failure
+        # is swallowed (XCom-gated via skip_or_start); every other task type
+        # must fail the chain on a failed job
+        preload = task_type == TaskType.PRELOAD
         kwargs.update({'pool': kwargs.get('pool', self.pool)})
         kwargs.update({'retry_delay': timedelta(seconds=self.retry_delay_in_seconds)})
         # explicit --scheduledDate override — popped unconditionally: BaseOperator
@@ -167,22 +171,13 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
                         get_completion_status_id = task_id + '_get_completion_status'
                         source_task_id=job_task.task_id
                         bash_command = (f"value=`gcloud beta run jobs executions describe {{{{task_instance.xcom_pull(key=None, task_ids='{source_task_id}')}}}} --region {self.cloud_run_job_region} --project {self.project_id} --format='value(status.failedCount, status.cancelledCounts)' {self.impersonate_service_account}| sed 's/[[:blank:]]//g'`; test -z \"$value\"")
-                        if kwargs.get('do_xcom_push', False):
-                            bash_command=f"""
-                            set -e
-                            bash -c '
-                            {bash_command.replace("'", '"')}
-                            return_code=$?
-
-                            # Push the return code to XCom
-                            echo $return_code
-
-                            # Exit with the captured return code if non-zero
-                            # if [ $return_code -ne 0 ]; then
-                            #     exit $return_code
-                            # fi
-                            '
-                            """
+                        # story 6.3 (issue #92) — do_xcom_push is forced True
+                        # above for the submission XCom (structural); it must
+                        # NOT select the exit-swallowing wrapper here: only
+                        # PRELOAD swallows, every other task type keeps the
+                        # active `exit $return_code` trailer so a failed
+                        # execution fails the chain
+                        bash_command = StarlakeAirflowJob._sl_xcom_wrapped_command(bash_command.replace("'", '"'), preload)
                         job_status = StarlakeBashOperator(
                             task_id=get_completion_status_id,
                             dataset=dataset,
@@ -210,6 +205,8 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
                         overrides=job_overrides,
                         mode=CloudRunMode.ASYNC,
                         impersonation_chain=self.impersonate_service_account,
+                        preload=preload,
+                        retry_on_failure=self.retry_on_failure,
                         **kwargs
                     )
                     check_completion_id = task_id + '_check_completion'
@@ -219,6 +216,7 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
                         source=self.source,
                         source_task_id=job_task.task_id,
                         impersonation_chain=self.impersonate_service_account,
+                        preload=preload,
                         **kwargs
                     )
 
@@ -235,21 +233,11 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
                     f"--wait --region {self.cloud_run_job_region} --project {self.project_id} --format='get(metadata.name)' {self.impersonate_service_account}" #--task-timeout 300 
                 )
                 if kwargs.get('do_xcom_push', False):
-                    bash_command=f"""
-                    set -e
-                    bash -c '
-                    {bash_command.replace("'", '"')}
-                    return_code=$?
-
-                    # Push the return code to XCom
-                    echo $return_code
-
-                    # Exit with the captured return code if non-zero
-                    # if [ $return_code -ne 0 ]; then
-                    #     exit $return_code
-                    # fi
-                    '
-                    """
+                    # story 6.3 (issue #92) — wrapper variant keyed on the
+                    # task type, not on do_xcom_push: preload swallows the
+                    # exit code (XCom-gated), every other task type keeps the
+                    # active `exit $return_code` trailer
+                    bash_command = StarlakeAirflowJob._sl_xcom_wrapped_command(bash_command.replace("'", '"'), preload)
                 kwargs.pop('do_xcom_push', None)
                 return StarlakeBashOperator(
                     task_id=task_id,
@@ -277,6 +265,8 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
                     overrides=job_overrides,
                     mode=CloudRunMode.SYNC,
                     impersonation_chain=self.impersonate_service_account,
+                    preload=preload,
+                    retry_on_failure=self.retry_on_failure,
                     **kwargs
                 )
 
@@ -317,22 +307,11 @@ class GCloudRunJobCompletionSensor(StarlakeDatasetMixin, BashSensor):
         else:
             bash_command=(f"value=`gcloud beta run jobs executions describe {{{{task_instance.xcom_pull(key='return_value', task_ids='{source_task_id}')}}}}  --region {cloud_run_job_region} --project {project_id} --format='value(status.completionTime, status.cancelledCounts)' {impersonate_service_account}| sed 's/[[:blank:]]//g'`; test -n \"$value\"")
 
-        if kwargs.get('do_xcom_push', False) and retry_on_failure:
-            bash_command=f"""
-            set -e
-            bash -c '
-            {bash_command.replace("'", '"')}
-            return_code=$?
-
-            # Push the return code to XCom
-            echo $return_code
-
-            # Exit with the captured return code if non-zero
-            # if [ $return_code -ne 0 ]; then
-            #     exit $return_code
-            # fi
-            '
-            """
+        # story 6.3 (issue #92) — the echo/XCom wrapper is NEVER applied to a
+        # sensor command: BashSensor's protocol needs the true exit code
+        # (0=done, retry_exit_code=2=poke again, 1=fail); the wrapper always
+        # exited 0 and would complete the sensor on the first poke regardless
+        # of the execution state
         super().__init__(
             task_id=task_id,
             dataset=dataset,
@@ -349,23 +328,27 @@ class CloudRunJobOperator(StarlakeDatasetMixin, CloudRunExecuteJobOperator):
 
     def __init__(
         self,
-        task_id: str, 
+        task_id: str,
         dataset: Optional[Union[StarlakeDataset, str]],
         source: Optional[str],
         mode: CloudRunMode = CloudRunMode.SYNC,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: Union[str, Sequence[str], None] = None,
+        preload: bool = False,
+        retry_on_failure: bool = False,
         **kwargs,
     ):
         super().__init__(  # type: ignore
             task_id=task_id,
             dataset=dataset,
             source=source,
-            gcp_conn_id=gcp_conn_id, 
-            impersonation_chain=impersonation_chain, 
+            gcp_conn_id=gcp_conn_id,
+            impersonation_chain=impersonation_chain,
             **kwargs
         )
         self.mode = mode
+        self.preload = preload
+        self.retry_on_failure = retry_on_failure
 
     def execute(self, context: Context):
         logger = logging.getLogger(__name__)
@@ -391,11 +374,21 @@ class CloudRunJobOperator(StarlakeDatasetMixin, CloudRunExecuteJobOperator):
         else:
             try:
                 job = super(CloudRunJobOperator, self).execute(context)
-                if self.do_xcom_push:
+                # Airflow 3 Task-SDK operators have no xcom_push attribute —
+                # the "job" XCom is a best-effort extra, never gated on
+                if self.do_xcom_push and hasattr(self, "xcom_push"):
                     self.xcom_push(context, key="job", value=job)
                 return True
             except Exception as e:
                 logger.exception(msg=f"Task {self.task_id} has failed")
+                # story 6.3 (issue #92) — single verdict source: only preload
+                # with retry_on_failure=false swallows (the False return value
+                # feeds the skip_or_start XCom gating); a failed
+                # load/transform/stage always fails the task, and
+                # retry_on_failure=true re-raises even for preload
+                # (retries-as-poke workaround, #91)
+                if not StarlakeAirflowJob._sl_cloud_failure_swallowed(self.preload, self.retry_on_failure):
+                    raise e
                 return False
 
 class CloudRunJobCompletionSensor(StarlakeDatasetMixin, BaseSensorOperator):
@@ -405,24 +398,26 @@ class CloudRunJobCompletionSensor(StarlakeDatasetMixin, BaseSensorOperator):
     def __init__(
         self,
         *,
-        task_id: str, 
+        task_id: str,
         dataset: Optional[Union[StarlakeDataset, str]],
         source: Optional[str],
         source_task_id: str,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: Union[str, Sequence[str], None] = None,
+        preload: bool = False,
         **kwargs,
     ):
         super().__init__(
             task_id=task_id,
             dataset=dataset,
             source=source,
-            mode="reschedule", 
+            mode="reschedule",
             **kwargs
         )
         self.source_task_id = source_task_id
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
+        self.preload = preload
 
     def poke(self, context: Context):
         hook = CloudRunHook(
@@ -438,14 +433,17 @@ class CloudRunJobCompletionSensor(StarlakeDatasetMixin, BaseSensorOperator):
             # An operation can only have one of those two combinations: if it is failed, then
             # the error field will be populated, else, then the response field will be.
             if operation.error.SerializeToString():
-                if self.do_xcom_push:
-                    self.log.error(
-                        f"{operation.error.message} [{operation.error.code}]"
-                    )
-                    return PokeReturnValue(True, False)
-                else:
-                    raise AirflowException(
-                        f"{operation.error.message} [{operation.error.code}]"
-                    )
+                self.log.error(
+                    f"{operation.error.message} [{operation.error.code}]"
+                )
+                # story 6.3 (issue #92) — verdict keyed on the task type, NOT
+                # on do_xcom_push (which defaults to True on BaseOperator and
+                # silently selected the swallow branch for every task type):
+                # preload completes with a falsy XCom (skip_or_start gating),
+                # anything else raises
+                return StarlakeAirflowJob._sl_cloud_poke_failure(
+                    self.preload,
+                    f"{operation.error.message} [{operation.error.code}]",
+                )
             return PokeReturnValue(True, True)
         return PokeReturnValue(False, False)

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_job.py
@@ -37,12 +37,15 @@ from ai.starlake.airflow.compat import (
     BaseOperator,
     Dataset,
     EmptyOperator,
+    PokeReturnValue,
     ShortCircuitOperator,
     TaskGroup,
     get_current_context,
     supports_assets,
     supports_inlet_events,
 )
+
+from airflow.exceptions import AirflowException
 
 from airflow.models import DagRun, TaskInstance
 
@@ -668,6 +671,84 @@ class StarlakeAirflowJob(IStarlakeJob[BaseOperator, Dataset], StarlakeAirflowOpt
                 f"instead (retries / retry_delay options)"
                 f"{workaround_requirements.get(env_name, '')}"
             )
+
+    @classmethod
+    def _sl_xcom_wrapped_command(cls, command: str, preload: bool) -> str:
+        """Wrap a bash command in the echo/XCom wrapper (story 6.3, issue #92).
+
+        Single source for the wrapper previously duplicated across the bash
+        and cloud_run gcloud paths. Two variants, selected by the task type
+        (never by ``do_xcom_push``, which defaults to True and is forced for
+        structural XCom plumbing):
+
+        - ``preload=True``: the exit code is SWALLOWED — echoed to XCom for
+          the downstream ``skip_or_start`` ShortCircuitOperator (``0`` →
+          proceed, non-zero → skip); the task itself ends green. This is the
+          one task type designed around XCom gating.
+        - ``preload=False`` (load/transform/stage): the exit code is echoed
+          AND re-raised via the active ``exit $return_code`` trailer — a
+          failed job must fail the task.
+
+        Lives in this provider-free base module so the contract stays
+        testable without the google/amazon provider packages.
+        """
+        if preload:
+            return f"""
+                set -e
+                bash -c '
+                {command}
+                return_code=$?
+
+                # Push the return code to XCom
+                echo $return_code
+
+                '
+                """
+        else:
+            return f"""
+                set -e
+                bash -c '
+                {command}
+                return_code=$?
+
+                # Push the return code to XCom
+                echo $return_code
+
+                # Exit with the captured return code if non-zero
+                if [ $return_code -ne 0 ]; then
+                    exit $return_code
+                fi
+                '
+                """
+
+    @classmethod
+    def _sl_cloud_failure_swallowed(cls, preload: bool, retry_on_failure: bool) -> bool:
+        """Whether a cloud operator may swallow a failed job (story 6.3, issue #92).
+
+        Only PRELOAD with ``retry_on_failure=false`` swallows (its failure is
+        gated through the ``skip_or_start`` XCom composition); every other
+        combination must propagate — a failed load/transform/stage reports a
+        failed task, and ``retry_on_failure=true`` re-raises even for preload
+        (the retries-as-poke workaround documented in #91).
+        """
+        return preload and not retry_on_failure
+
+    @classmethod
+    def _sl_cloud_poke_failure(cls, preload: bool, message: str) -> PokeReturnValue:
+        """Failure verdict for a cloud completion sensor poke (story 6.3, issue #92).
+
+        For PRELOAD the sensor completes with a falsy XCom
+        (``PokeReturnValue(True, False)``) so ``skip_or_start`` skips the
+        downstream loads — the swallow is the gating design. For every other
+        task type the sensor must FAIL the chain: ``PokeReturnValue`` truthiness
+        is ``is_done``, so returning it would end the sensor green.
+
+        Raises:
+            AirflowException: when ``preload`` is False.
+        """
+        if preload:
+            return PokeReturnValue(True, False)
+        raise AirflowException(message)
 
     def skip_or_start_op(self, task_id: str, upstream_task: BaseOperator, **kwargs) -> Optional[BaseOperator]:
         """

--- a/starlake-airflow/src/main/python/setup.py
+++ b/starlake-airflow/src/main/python/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 import os
 
-version = os.environ.get("PROJECT_VERSION", "0.6.3")
+version = os.environ.get("PROJECT_VERSION", "0.6.4")
 
 setup(name='starlake-airflow',
       version=version,

--- a/tests/airflow/test_airflow_cloud_failure_propagation.py
+++ b/tests/airflow/test_airflow_cloud_failure_propagation.py
@@ -1,0 +1,637 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Story 6.3 (issue #92) — cloud engines must fail the task chain on a failed job.
+
+Contract: a failed Starlake job fails the Airflow task for every task type
+except PRELOAD (the one type designed around the ``skip_or_start`` XCom
+gating), under default options, on every cloud engine/mode.
+
+Two layers:
+
+- provider-free contract tests (run in CI, which installs NO google/amazon
+  providers): the shared wrapper builder and the swallow/poke verdict
+  helpers on ``StarlakeAirflowJob``, plus the bash-job wrapper regression;
+- provider-guarded operator tests (skipped without
+  ``apache-airflow-providers-amazon`` / ``-google``): the real
+  ``FargateTaskOperator`` / ``CloudRunJobOperator`` / completion sensors and
+  the ``sl_job`` wrapper selection per task type.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.airflow.conftest import _AIRFLOW_TEST_MODULE_NAME, AIRFLOW_AVAILABLE
+
+pytestmark = pytest.mark.skipif(
+    not AIRFLOW_AVAILABLE,
+    reason="Requires Apache Airflow",
+)
+
+try:
+    import airflow.providers.amazon.aws.operators.ecs  # noqa: F401
+    AMAZON_AVAILABLE = True
+except Exception:
+    AMAZON_AVAILABLE = False
+
+try:
+    import airflow.providers.google.cloud.operators.cloud_run  # noqa: F401
+    import google.cloud.run_v2  # noqa: F401
+    GOOGLE_AVAILABLE = True
+except Exception:
+    GOOGLE_AVAILABLE = False
+
+amazon_only = pytest.mark.skipif(
+    not AMAZON_AVAILABLE,
+    reason="Requires apache-airflow-providers-amazon",
+)
+google_only = pytest.mark.skipif(
+    not GOOGLE_AVAILABLE,
+    reason="Requires apache-airflow-providers-google",
+)
+
+ACTIVE_EXIT = "if [ $return_code -ne 0 ]; then"
+
+CLOUD_RUN_OPTIONS = {
+    "cloud_run_job_name": "test-job",
+    "cloud_run_project_id": "test-project",
+    "cloud_run_job_region": "europe-west1",
+    "pre_load_strategy": "imported",
+}
+
+FARGATE_OPTIONS = {
+    "aws_cluster_name": "test-cluster",
+    "aws_task_definition_name": "test-task-def",
+    "aws_task_definition_container_name": "test-container",
+    "pre_load_strategy": "imported",
+}
+
+
+def _dag():
+    from airflow import DAG
+    from datetime import datetime
+    return DAG(dag_id="test_cloud_failure_propagation", start_date=datetime(2024, 1, 1), schedule=None)
+
+
+# ---------------------------------------------------------------------------
+# 1. Provider-free — shared echo/XCom wrapper builder
+# ---------------------------------------------------------------------------
+
+class TestXComWrappedCommand:
+
+    def test_preload_variant_swallows_exit_code(self):
+        from ai.starlake.airflow import StarlakeAirflowJob
+
+        wrapped = StarlakeAirflowJob._sl_xcom_wrapped_command("starlake preload", preload=True)
+        assert "starlake preload" in wrapped
+        assert "return_code=$?" in wrapped
+        assert "echo $return_code" in wrapped
+        # the swallow: NO active exit trailer at all
+        assert ACTIVE_EXIT not in wrapped
+        assert "exit $return_code" not in wrapped
+
+    def test_non_preload_variant_propagates_exit_code(self):
+        from ai.starlake.airflow import StarlakeAirflowJob
+
+        wrapped = StarlakeAirflowJob._sl_xcom_wrapped_command("starlake load", preload=False)
+        assert "starlake load" in wrapped
+        assert "return_code=$?" in wrapped
+        assert "echo $return_code" in wrapped
+        # ACTIVE (uncommented) exit trailer — a failed job fails the task
+        assert ACTIVE_EXIT in wrapped
+        assert "exit $return_code" in wrapped
+        assert "# if [ $return_code -ne 0 ]; then" not in wrapped
+        assert "#     exit $return_code" not in wrapped
+
+    def test_non_preload_variant_byte_equal_to_pre_refactor_bash_wrapper(self):
+        """AC6 — the helper's non-preload variant is byte-identical to the
+        wrapper string the bash job shipped before the refactor."""
+        from ai.starlake.airflow import StarlakeAirflowJob
+
+        expected = (
+            "\n"
+            "                set -e\n"
+            "                bash -c '\n"
+            "                starlake load\n"
+            "                return_code=$?\n"
+            "\n"
+            "                # Push the return code to XCom\n"
+            "                echo $return_code\n"
+            "\n"
+            "                # Exit with the captured return code if non-zero\n"
+            "                if [ $return_code -ne 0 ]; then\n"
+            "                    exit $return_code\n"
+            "                fi\n"
+            "                '\n"
+            "                "
+        )
+        assert StarlakeAirflowJob._sl_xcom_wrapped_command("starlake load", preload=False) == expected
+
+
+# ---------------------------------------------------------------------------
+# 2. Provider-free — swallow verdict matrix (the issue #92 contract)
+# ---------------------------------------------------------------------------
+
+class TestCloudFailureSwallowedVerdict:
+
+    @pytest.mark.parametrize(
+        "preload, retry_on_failure, swallowed",
+        [
+            (False, False, False),  # THE bug: load/transform must propagate by default
+            (False, True, False),
+            (True, False, True),    # preload keeps its swallow (skip_or_start gating)
+            (True, True, False),    # retries-as-poke workaround (#91) re-raises
+        ],
+    )
+    def test_matrix(self, preload, retry_on_failure, swallowed):
+        from ai.starlake.airflow import StarlakeAirflowJob
+
+        assert StarlakeAirflowJob._sl_cloud_failure_swallowed(preload, retry_on_failure) is swallowed
+
+
+class TestCloudPokeFailureVerdict:
+
+    def test_preload_completes_with_falsy_xcom(self):
+        from ai.starlake.airflow import StarlakeAirflowJob
+
+        verdict = StarlakeAirflowJob._sl_cloud_poke_failure(True, "job failed")
+        assert verdict.is_done is True
+        assert verdict.xcom_value is False
+
+    def test_non_preload_raises(self):
+        from airflow.exceptions import AirflowException
+        from ai.starlake.airflow import StarlakeAirflowJob
+
+        with pytest.raises(AirflowException, match="job failed"):
+            StarlakeAirflowJob._sl_cloud_poke_failure(False, "job failed")
+
+
+# ---------------------------------------------------------------------------
+# 3. Provider-free — bash job wrapper regression (refactor onto the helper)
+# ---------------------------------------------------------------------------
+
+class TestBashJobWrapperRegression:
+
+    def _make_job(self):
+        from ai.starlake.airflow.bash import StarlakeAirflowBashJob
+        return StarlakeAirflowBashJob(
+            filename="test_cloud_failure_propagation.py",
+            module_name=_AIRFLOW_TEST_MODULE_NAME,
+            options={"pre_load_strategy": "imported"},
+        )
+
+    def test_preload_keeps_swallow_wrapper(self):
+        job = self._make_job()
+        task = job.sl_pre_load(domain="starbake", tables={"customers"})
+        assert "return_code=$?" in task.bash_command
+        assert "echo $return_code" in task.bash_command
+        assert ACTIVE_EXIT not in task.bash_command
+
+    def test_load_with_xcom_push_keeps_active_exit(self):
+        job = self._make_job()
+        task = job.sl_load(
+            task_id="load_customers",
+            domain="starbake",
+            table="customers",
+            do_xcom_push=True,
+        )
+        assert "return_code=$?" in task.bash_command
+        assert ACTIVE_EXIT in task.bash_command
+
+    def test_load_without_xcom_push_stays_raw(self):
+        job = self._make_job()
+        task = job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        assert "return_code=$?" not in task.bash_command
+
+
+# ---------------------------------------------------------------------------
+# 4. Fargate — operator failure propagation (provider-guarded)
+# ---------------------------------------------------------------------------
+
+@amazon_only
+class TestFargateTaskOperatorExecute:
+
+    def _make_operator(self, monkeypatch, *, preload, retry_on_failure, error):
+        from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
+        from ai.starlake.airflow.aws.starlake_airflow_fargate_job import FargateTaskOperator
+
+        def boom(self, context):
+            raise error
+
+        monkeypatch.setattr(EcsRunTaskOperator, "execute", boom)
+        with _dag():
+            op = FargateTaskOperator(
+                task_id="fargate_task",
+                dataset=None,
+                source=None,
+                task_definition="test-task-def",
+                cluster="test-cluster",
+                overrides={},
+                wait_for_completion=True,
+                retry_on_failure=retry_on_failure,
+                preload=preload,
+            )
+        return op
+
+    def test_non_preload_default_reraises(self, monkeypatch):
+        """THE issue #92 fargate bug: a failed load/transform must fail the
+        task even with retry_on_failure=false (the default)."""
+        error = RuntimeError("ECS task failed")
+        op = self._make_operator(monkeypatch, preload=False, retry_on_failure=False, error=error)
+        with pytest.raises(RuntimeError, match="ECS task failed"):
+            op.execute(context={})
+
+    def test_non_preload_retry_on_failure_reraises(self, monkeypatch):
+        error = RuntimeError("ECS task failed")
+        op = self._make_operator(monkeypatch, preload=False, retry_on_failure=True, error=error)
+        with pytest.raises(RuntimeError):
+            op.execute(context={})
+
+    def test_preload_default_swallows_returning_false(self, monkeypatch):
+        """The returned False becomes the return_value XCom (do_xcom_push is
+        forced by sl_pre_load) — skip_or_start then skips downstream."""
+        error = RuntimeError("ECS task failed")
+        op = self._make_operator(monkeypatch, preload=True, retry_on_failure=False, error=error)
+        assert op.execute(context={}) is False
+
+    def test_preload_retry_on_failure_reraises(self, monkeypatch):
+        """Preload + retry_on_failure=true is the retries-as-poke workaround
+        (#91) — it must still re-raise."""
+        error = RuntimeError("ECS task failed")
+        op = self._make_operator(monkeypatch, preload=True, retry_on_failure=True, error=error)
+        with pytest.raises(RuntimeError):
+            op.execute(context={})
+
+    def test_success_returns_true(self, monkeypatch):
+        from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
+        from ai.starlake.airflow.aws.starlake_airflow_fargate_job import FargateTaskOperator
+
+        monkeypatch.setattr(EcsRunTaskOperator, "execute", lambda self, context: None)
+        with _dag():
+            op = FargateTaskOperator(
+                task_id="fargate_task",
+                dataset=None,
+                source=None,
+                task_definition="test-task-def",
+                cluster="test-cluster",
+                overrides={},
+                wait_for_completion=True,
+            )
+        assert op.execute(context={}) is True
+
+
+@amazon_only
+class TestFargateTaskStateSensorPoke:
+
+    def _make_sensor(self, monkeypatch, *, preload, describe_result):
+        from ai.starlake.airflow.aws.starlake_airflow_fargate_job import FargateTaskStateSensor
+
+        with _dag():
+            sensor = FargateTaskStateSensor(
+                task_id="fargate_check_completion",
+                dataset=None,
+                source=None,
+                cluster="test-cluster",
+                task="arn:aws:ecs:task/test",
+                preload=preload,
+            )
+        mock_hook = MagicMock()
+        mock_hook.conn.describe_tasks.return_value = describe_result
+        monkeypatch.setattr(type(sensor), "hook", property(lambda self: mock_hook))
+        return sensor
+
+    FAILED_TASK = {"tasks": [{"lastStatus": "STOPPED", "containers": [{"exitCode": 1}]}]}
+    SUCCEEDED_TASK = {"tasks": [{"lastStatus": "STOPPED", "containers": [{"exitCode": 0}]}]}
+
+    def test_non_preload_failure_raises(self, monkeypatch):
+        """V1 (issue #92): PokeReturnValue(True, False) COMPLETED the sensor
+        on a failed ECS task — non-preload must now raise."""
+        from airflow.exceptions import AirflowException
+
+        sensor = self._make_sensor(monkeypatch, preload=False, describe_result=self.FAILED_TASK)
+        with pytest.raises(AirflowException):
+            sensor.poke(context={})
+
+    def test_preload_failure_completes_with_falsy_xcom(self, monkeypatch):
+        sensor = self._make_sensor(monkeypatch, preload=True, describe_result=self.FAILED_TASK)
+        verdict = sensor.poke(context={})
+        assert verdict.is_done is True
+        assert verdict.xcom_value is False
+
+    def test_success_completes_truthy(self, monkeypatch):
+        sensor = self._make_sensor(monkeypatch, preload=False, describe_result=self.SUCCEEDED_TASK)
+        verdict = sensor.poke(context={})
+        assert verdict.is_done is True
+        assert verdict.xcom_value is True
+
+    def test_describe_error_non_preload_raises(self, monkeypatch):
+        from airflow.exceptions import AirflowException
+        from ai.starlake.airflow.aws.starlake_airflow_fargate_job import FargateTaskStateSensor
+
+        with _dag():
+            sensor = FargateTaskStateSensor(
+                task_id="fargate_check_completion",
+                dataset=None,
+                source=None,
+                cluster="test-cluster",
+                task="arn:aws:ecs:task/test",
+                preload=False,
+            )
+        mock_hook = MagicMock()
+        mock_hook.conn.describe_tasks.side_effect = RuntimeError("boto error")
+        monkeypatch.setattr(type(sensor), "hook", property(lambda self: mock_hook))
+        with pytest.raises(AirflowException):
+            sensor.poke(context={})
+
+    def test_hook_airflow_exception_preload_still_swallowed(self, monkeypatch):
+        """An AirflowException raised by the hook itself must not bypass the
+        preload swallow (the verdict is emitted outside the try block)."""
+        from airflow.exceptions import AirflowException
+        from ai.starlake.airflow.aws.starlake_airflow_fargate_job import FargateTaskStateSensor
+
+        with _dag():
+            sensor = FargateTaskStateSensor(
+                task_id="fargate_check_completion",
+                dataset=None,
+                source=None,
+                cluster="test-cluster",
+                task="arn:aws:ecs:task/test",
+                preload=True,
+            )
+        mock_hook = MagicMock()
+        mock_hook.conn.describe_tasks.side_effect = AirflowException("conn 'aws_default' not found")
+        monkeypatch.setattr(type(sensor), "hook", property(lambda self: mock_hook))
+        verdict = sensor.poke(context={})
+        assert verdict.is_done is True
+        assert verdict.xcom_value is False
+
+    def test_running_status_pokes_again(self, monkeypatch):
+        sensor = self._make_sensor(
+            monkeypatch, preload=False,
+            describe_result={"tasks": [{"lastStatus": "RUNNING", "containers": []}]},
+        )
+        assert sensor.poke(context={}) is None
+
+
+@amazon_only
+class TestFargateSlJobConstruction:
+
+    def _make_job(self, extra_options=None):
+        from ai.starlake.airflow.aws import StarlakeAirflowFargateJob
+        options = dict(FARGATE_OPTIONS)
+        options.update(extra_options or {})
+        return StarlakeAirflowFargateJob(
+            filename="test_cloud_failure_propagation.py",
+            module_name=_AIRFLOW_TEST_MODULE_NAME,
+            options=options,
+        )
+
+    def test_sync_load_task_is_not_preload(self):
+        job = self._make_job({"fargate_async": "false"})
+        with _dag():
+            task = job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        assert task.preload is False
+        assert task.retry_on_failure is False
+        assert task.wait_for_completion is True
+
+    def test_sync_preload_task_is_preload(self):
+        job = self._make_job({"fargate_async": "false"})
+        with _dag():
+            task = job.sl_pre_load(domain="starbake", tables={"customers"})
+        assert task.preload is True
+
+    def test_async_group_threads_preload_flag(self):
+        job = self._make_job()
+        with _dag() as dag:
+            job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        submission = dag.get_task("load_customers_wait.load_customers")
+        completion = dag.get_task("load_customers_wait.load_customers_check_completion")
+        assert submission.preload is False
+        assert completion.preload is False
+
+    def test_async_preload_group_threads_preload_flag(self):
+        job = self._make_job()
+        with _dag() as dag:
+            job.sl_pre_load(domain="starbake", tables={"customers"})
+        submission, completion = (
+            dag.get_task(tid) for tid in sorted(dag.task_ids)
+        )
+        assert submission.preload is True
+        assert completion.preload is True
+
+
+# ---------------------------------------------------------------------------
+# 5. Cloud Run — gcloud wrapper selection + operator/sensor verdicts
+# ---------------------------------------------------------------------------
+
+@google_only
+class TestCloudRunGcloudWrapperSelection:
+
+    def _make_job(self, extra_options=None):
+        from ai.starlake.airflow.gcp import StarlakeAirflowCloudRunJob
+        options = dict(CLOUD_RUN_OPTIONS)
+        options.update(extra_options or {})
+        return StarlakeAirflowCloudRunJob(
+            filename="test_cloud_failure_propagation.py",
+            module_name=_AIRFLOW_TEST_MODULE_NAME,
+            options=options,
+        )
+
+    def test_async_status_task_load_has_active_exit(self):
+        """THE issue #92 cloud_run bug: the _get_completion_status task's
+        wrapper had the exit block commented out — a failed execution ended
+        the chain green for load/transform under default options."""
+        job = self._make_job()
+        with _dag() as dag:
+            job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        status = dag.get_task("load_customers_wait.load_customers_get_completion_status")
+        assert "return_code=$?" in status.bash_command
+        assert ACTIVE_EXIT in status.bash_command
+        assert "# if [ $return_code -ne 0 ]; then" not in status.bash_command
+
+    def test_async_submission_task_keeps_xcom_push(self):
+        job = self._make_job()
+        with _dag() as dag:
+            job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        submission = dag.get_task("load_customers_wait.load_customers")
+        # structural: the completion sensor pulls the execution name from it
+        assert submission.do_xcom_push is True
+
+    def test_async_status_task_preload_keeps_swallow(self):
+        job = self._make_job()
+        with _dag() as dag:
+            job.sl_pre_load(domain="starbake", tables={"customers"})
+        status = next(
+            dag.get_task(tid) for tid in dag.task_ids if tid.endswith("_get_completion_status")
+        )
+        assert "return_code=$?" in status.bash_command
+        assert "echo $return_code" in status.bash_command
+        assert ACTIVE_EXIT not in status.bash_command
+
+    def test_completion_sensor_never_wrapped(self):
+        """V4 (issue #92): the retry_on_failure sensor command was wrapped in
+        the swallow wrapper (always exit 0), destroying the sensor's
+        0/retry_exit_code/1 protocol."""
+        job = self._make_job({"retry_on_failure": "true"})
+        with _dag() as dag:
+            job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        sensor = dag.get_task("load_customers_wait.load_customers_check_completion")
+        assert "return_code=$?" not in sensor.bash_command
+        assert "exit 2" in sensor.bash_command  # retry_exit_code protocol intact
+
+    def test_sync_gcloud_load_with_xcom_push_has_active_exit(self):
+        job = self._make_job({"cloud_run_async": "false"})
+        with _dag():
+            task = job.sl_load(
+                task_id="load_customers", domain="starbake", table="customers",
+                do_xcom_push=True,
+            )
+        assert ACTIVE_EXIT in task.bash_command
+
+    def test_sync_gcloud_preload_keeps_swallow(self):
+        job = self._make_job({"cloud_run_async": "false"})
+        with _dag():
+            task = job.sl_pre_load(domain="starbake", tables={"customers"})
+        assert "return_code=$?" in task.bash_command
+        assert ACTIVE_EXIT not in task.bash_command
+
+
+@google_only
+class TestCloudRunJobOperatorExecute:
+
+    def _make_operator(self, monkeypatch, *, preload, retry_on_failure=False, error=None):
+        from airflow.providers.google.cloud.operators.cloud_run import CloudRunExecuteJobOperator
+        from ai.starlake.airflow.gcp.starlake_airflow_cloud_run_job import (
+            CloudRunJobOperator, CloudRunMode,
+        )
+
+        if error is not None:
+            def boom(self, context):
+                raise error
+            monkeypatch.setattr(CloudRunExecuteJobOperator, "execute", boom)
+        with _dag():
+            op = CloudRunJobOperator(
+                task_id="cloud_run_task",
+                dataset=None,
+                source=None,
+                project_id="test-project",
+                region="europe-west1",
+                job_name="test-job",
+                overrides={},
+                mode=CloudRunMode.SYNC,
+                preload=preload,
+                retry_on_failure=retry_on_failure,
+            )
+        # Airflow 3 operators have no xcom_push attribute — raising=False
+        monkeypatch.setattr(op, "xcom_push", MagicMock(), raising=False)
+        return op
+
+    def test_sync_non_preload_failure_reraises(self, monkeypatch):
+        """V2 (issue #92): the sync python-operator path returned False on
+        exception — the task ended green on a failed job."""
+        op = self._make_operator(monkeypatch, preload=False, error=RuntimeError("job failed"))
+        with pytest.raises(RuntimeError, match="job failed"):
+            op.execute(context={})
+
+    def test_sync_preload_failure_returns_false(self, monkeypatch):
+        op = self._make_operator(monkeypatch, preload=True, error=RuntimeError("job failed"))
+        assert op.execute(context={}) is False
+
+    def test_sync_preload_retry_on_failure_reraises(self, monkeypatch):
+        """retry_on_failure=true re-raises even for preload — the #91
+        retries-as-poke workaround on the cloud_run python sync path."""
+        op = self._make_operator(
+            monkeypatch, preload=True, retry_on_failure=True,
+            error=RuntimeError("job failed"),
+        )
+        with pytest.raises(RuntimeError, match="job failed"):
+            op.execute(context={})
+
+    def test_sync_python_sl_job_threads_flags(self):
+        """The non-gcloud sync construction site threads preload AND
+        retry_on_failure from the job configuration."""
+        from ai.starlake.airflow.gcp import StarlakeAirflowCloudRunJob
+        options = dict(CLOUD_RUN_OPTIONS)
+        options.update({
+            "cloud_run_async": "false",
+            "use_gcloud": "false",
+            "retry_on_failure": "true",
+        })
+        job = StarlakeAirflowCloudRunJob(
+            filename="test_cloud_failure_propagation.py",
+            module_name=_AIRFLOW_TEST_MODULE_NAME,
+            options=options,
+        )
+        with _dag():
+            load_task = job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+            preload_task = job.sl_pre_load(domain="starbake", tables={"customers"})
+        assert load_task.preload is False
+        assert load_task.retry_on_failure is True
+        assert preload_task.preload is True
+        assert preload_task.retry_on_failure is True
+
+
+@google_only
+class TestCloudRunJobCompletionSensorPoke:
+
+    def _make_sensor(self, monkeypatch, *, preload, error_bytes):
+        import ai.starlake.airflow.gcp.starlake_airflow_cloud_run_job as cloud_run_module
+        from ai.starlake.airflow.gcp.starlake_airflow_cloud_run_job import (
+            CloudRunJobCompletionSensor,
+        )
+
+        with _dag():
+            sensor = CloudRunJobCompletionSensor(
+                task_id="cloud_run_check_completion",
+                dataset=None,
+                source=None,
+                source_task_id="cloud_run_task",
+                preload=preload,
+            )
+        operation = MagicMock()
+        operation.done = True
+        operation.error.SerializeToString.return_value = error_bytes
+        operation.error.message = "job failed"
+        operation.error.code = 3
+        mock_hook_cls = MagicMock()
+        mock_hook_cls.return_value.get_conn.return_value.get_operation.return_value = operation
+        monkeypatch.setattr(cloud_run_module, "CloudRunHook", mock_hook_cls)
+        monkeypatch.setattr(sensor, "xcom_pull", MagicMock(return_value="operation-name"))
+        return sensor
+
+    def test_non_preload_failure_raises(self, monkeypatch):
+        """V3 (issue #92): do_xcom_push defaults to True on BaseOperator, so
+        the old do_xcom_push-keyed branch swallowed every failure."""
+        from airflow.exceptions import AirflowException
+
+        sensor = self._make_sensor(monkeypatch, preload=False, error_bytes=b"\x08\x03")
+        with pytest.raises(AirflowException, match="job failed"):
+            sensor.poke(context={})
+
+    def test_preload_failure_completes_with_falsy_xcom(self, monkeypatch):
+        sensor = self._make_sensor(monkeypatch, preload=True, error_bytes=b"\x08\x03")
+        verdict = sensor.poke(context={})
+        assert verdict.is_done is True
+        assert verdict.xcom_value is False
+
+    def test_success_completes_truthy(self, monkeypatch):
+        sensor = self._make_sensor(monkeypatch, preload=False, error_bytes=b"")
+        verdict = sensor.poke(context={})
+        assert verdict.is_done is True
+        assert verdict.xcom_value is True


### PR DESCRIPTION
Closes #92

## Contract

**A failed Starlake job fails the Airflow task chain for every task type except PRELOAD**, under default options, on every cloud engine/mode. PRELOAD is the one task type designed around swallowing — its failure surfaces as a falsy `return_value` XCom that `skip_or_start` turns into a downstream skip. Swallow-vs-propagate is keyed on `preload = task_type == TaskType.PRELOAD` (threaded to operators/sensors as an explicit ctor flag) — never on `do_xcom_push` (defaults `True` on `BaseOperator`, and forced `True` for structural XCom plumbing) nor on `retry_on_failure` alone.

## Six swallow sites fixed (verification-first)

Unit probes against `main` confirmed the issue's two named mechanisms **and four more** the issue marked "NOT affected" (evidence posted on #92 before the fix):

| Engine × mode | Site | Before (default options) | After |
|---|---|---|---|
| Fargate sync | `FargateTaskOperator.execute` | catch-all swallow unless `retry_on_failure=true` — failed load/transform green | non-preload always re-raises; preload returns `False` (XCom gating) |
| Cloud Run async gcloud (default) | `_get_completion_status` task | wrapper's `exit $return_code` commented out → always exits 0 | preload-only swallow wrapper; non-preload gets the active-exit variant |
| Fargate async | `FargateTaskStateSensor.poke` | `PokeReturnValue(True, False)` on failure — sensor **completes green** (its truthiness is `is_done`) | preload → falsy complete; else `AirflowException` |
| Cloud Run sync python | `CloudRunJobOperator.execute` | `except: return False` — task green | verdict via `_sl_cloud_failure_swallowed(preload, retry_on_failure)` |
| Cloud Run async python | `CloudRunJobCompletionSensor.poke` | swallow branch keyed on `do_xcom_push` (default True) — always swallowed | preload-keyed verdict |
| Cloud Run async gcloud + `retry_on_failure=true` | `GCloudRunJobCompletionSensor` wrapper | swallow wrapper always exited 0, destroying the 0/`retry_exit_code=2`/1 protocol | wrapper removed — sensors always see true exit codes |

## Behavioral contracts

- **Preload keeps its swallow**: bash + gcloud echo/XCom wrappers unchanged byte-for-byte for preload; `f_skip_or_start` int-parsing of the echoed return code preserved; fargate/cloud_run preload + `retry_on_failure=true` re-raises (the #91 retries-as-poke workaround — on the cloud_run python sync path this now actually works; it was swallowed before).
- **Three provider-free seams on `StarlakeAirflowJob`** keep the contract CI-testable (CI installs no google/amazon providers): `_sl_xcom_wrapped_command(command, preload)`, `_sl_cloud_failure_swallowed(preload, retry_on_failure)` (consulted by both cloud operators), `_sl_cloud_poke_failure(preload, message)` (verdict emitted outside the poke `try` so infra `AirflowException`s can't bypass the preload swallow).
- **Airflow 3 compatibility**: fargate preload swallow now returns `False` (recorded as `return_value` via `do_xcom_push`) instead of calling `self.xcom_push`, which A3 Task-SDK operators don't have; the cloud-run success-path `xcom_push` is `hasattr`-guarded.
- **Bash job refactored onto the shared wrapper** — strings byte-identical (pinned by a byte-equality test + both existing suites untouched-green).

## Tests

New `tests/airflow/test_airflow_cloud_failure_propagation.py` (40 tests): provider-free contract layer (runs in CI) + amazon/google-guarded operator layer (skips cleanly in CI; run locally in constraints-pinned venvs with the providers installed). Red-green verified: 30 failures against `main` wheels before the fix.

- Airflow 2.10.5 (+ amazon + google providers): **259 passed**
- Airflow 3.3.0 (+ amazon; google provider uninstallable on macOS x86_64 under 3.3.0 constraints — `ray` wheel gap): **233 passed + 26 skipped** (13 documented v2-only + 13 google-provider)

## Docs & version

- starlake-airflow **0.6.3 → 0.6.4** (pom.xml + setup.py). No other module touched.
- README `retry_on_failure` rows (cloud_run + fargate) reworded to the preload-only semantics; ARCHITECTURE.md gained a "Cloud engine failure propagation" subsection. The #91-era preload-workaround docs describe PRELOAD semantics, which are preserved — verified, unchanged.

## Follow-up

- #95 (pre-existing, surfaced by the review): the gcloud/bash XCom wrapper mangles commands containing single quotes (`--scheduledDate`, `--options` values); previously silently swallowed, now fails loud. Fix direction: the wrapper helper should own the quoting contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
