### PR TITLE
fix(airflow): cloud_run impersonation_chain gets the bare service-account email, gcloud keeps the CLI fragment

### DIFF
--- a/starlake-airflow/pom.xml
+++ b/starlake-airflow/pom.xml
@@ -14,7 +14,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>starlake-airflow</artifactId>
-    <version>0.6.7</version>
+    <version>0.6.8</version>
     <packaging>jar</packaging>
 
 </project>

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/gcp/starlake_airflow_cloud_run_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/gcp/starlake_airflow_cloud_run_job.py
@@ -75,6 +75,11 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
         self.cloud_run_job_name = __class__.get_context_var(var_name='cloud_run_job_name', options=self.options) if not cloud_run_job_name else cloud_run_job_name
         self.cloud_run_job_region = __class__.get_context_var('cloud_run_job_region', default_value=os.getenv("GCP_REGION"), options=self.options) if not cloud_run_job_region else cloud_run_job_region
         self.cloud_run_service_account = __class__.get_context_var(var_name='cloud_run_service_account', default_value="", options=self.options) if not cloud_run_service_account else cloud_run_service_account
+        # issue #104 — two impersonation consumers, two formats: the gcloud
+        # command strings interpolate the CLI fragment below, while every
+        # provider `impersonation_chain=` site must receive the bare
+        # service-account email (`self.cloud_run_service_account or None`) —
+        # the Google auth layer cannot use the fragment
         if self.cloud_run_service_account:
             self.impersonate_service_account = f"--impersonate-service-account {self.cloud_run_service_account}"
         else:
@@ -191,7 +196,7 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
                 project_id=self.project_id,
                 job_name=self.cloud_run_job_name,
                 region=self.cloud_run_job_region,
-                impersonation_chain=self.impersonate_service_account,
+                impersonation_chain=self.cloud_run_service_account or None,
             )
             common.update(engine_kwargs)
             container_overrides: Dict[str, Any] = {
@@ -320,7 +325,7 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
                         region=self.cloud_run_job_region,
                         overrides=job_overrides,
                         mode=CloudRunMode.ASYNC,
-                        impersonation_chain=self.impersonate_service_account,
+                        impersonation_chain=self.cloud_run_service_account or None,
                         preload=preload,
                         retry_on_failure=self.retry_on_failure,
                         **kwargs
@@ -331,7 +336,7 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
                         dataset=dataset,
                         source=self.source,
                         source_task_id=job_task.task_id,
-                        impersonation_chain=self.impersonate_service_account,
+                        impersonation_chain=self.cloud_run_service_account or None,
                         preload=preload,
                         **kwargs
                     )
@@ -385,7 +390,7 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
                     region=self.cloud_run_job_region,
                     overrides=job_overrides,
                     mode=CloudRunMode.SYNC,
-                    impersonation_chain=self.impersonate_service_account,
+                    impersonation_chain=self.cloud_run_service_account or None,
                     preload=preload,
                     retry_on_failure=self.retry_on_failure,
                     **kwargs

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/gcp/starlake_airflow_cloud_run_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/gcp/starlake_airflow_cloud_run_job.py
@@ -74,7 +74,20 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
         self.project_id = __class__.get_context_var(var_name='cloud_run_project_id', default_value=os.getenv("GCP_PROJECT"), options=self.options) if not project_id else project_id
         self.cloud_run_job_name = __class__.get_context_var(var_name='cloud_run_job_name', options=self.options) if not cloud_run_job_name else cloud_run_job_name
         self.cloud_run_job_region = __class__.get_context_var('cloud_run_job_region', default_value=os.getenv("GCP_REGION"), options=self.options) if not cloud_run_job_region else cloud_run_job_region
-        self.cloud_run_service_account = __class__.get_context_var(var_name='cloud_run_service_account', default_value="", options=self.options) if not cloud_run_service_account else cloud_run_service_account
+        cloud_run_service_account = __class__.get_context_var(var_name='cloud_run_service_account', default_value="", options=self.options) if not cloud_run_service_account else cloud_run_service_account
+        # issue #105 — a single email string only: a sequence would render its
+        # Python repr into the gcloud fragment, and a comma/space-joined chain
+        # would reach the provider as one malformed principal; a delegation
+        # chain belongs in the per-call impersonation_chain kwarg
+        # (python-operator paths only)
+        if not isinstance(cloud_run_service_account, str) or any(c in cloud_run_service_account.strip() for c in ', '):
+            raise ValueError(
+                f"[{__class__.sl_orchestrator() or 'unknown'}] cloud_run: invalid value "
+                f"'{cloud_run_service_account}' for option 'cloud_run_service_account' — expected a single "
+                f"service-account email string (pass a delegation chain via the "
+                f"impersonation_chain kwarg on the python-operator paths)"
+            )
+        self.cloud_run_service_account = cloud_run_service_account.strip()
         # issue #104 — two impersonation consumers, two formats: the gcloud
         # command strings interpolate the CLI fragment below, while every
         # provider `impersonation_chain=` site must receive the bare
@@ -134,6 +147,17 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
         # explicit --scheduledDate override — popped unconditionally: BaseOperator
         # would reject the kwarg
         scheduled_date = kwargs.pop('scheduled_date', None)
+        # issue #105 — an explicit impersonation_chain kwarg (bare email or a
+        # delegation chain, both valid for the Google provider) is honored on
+        # the python-operator paths, resolved ONCE so the async operator and
+        # its completion sensor see the same value (it used to collide with
+        # the explicit ctor kwarg → TypeError at DAG parse). The gcloud paths
+        # keep rejecting it: a chain has no gcloud-fragment equivalent, and a
+        # silent pop would swallow user intent.
+        if not self.use_gcloud:
+            impersonation_chain = kwargs.pop('impersonation_chain', self.cloud_run_service_account or None)
+        else:
+            impersonation_chain = self.cloud_run_service_account or None
         if task_type is not None and (task_type == TaskType.LOAD or task_type == TaskType.TRANSFORM):
             arguments = [] if not arguments else arguments
             params: dict = kwargs.get('params', dict())
@@ -196,7 +220,7 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
                 project_id=self.project_id,
                 job_name=self.cloud_run_job_name,
                 region=self.cloud_run_job_region,
-                impersonation_chain=self.cloud_run_service_account or None,
+                impersonation_chain=impersonation_chain,
             )
             common.update(engine_kwargs)
             container_overrides: Dict[str, Any] = {
@@ -325,7 +349,7 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
                         region=self.cloud_run_job_region,
                         overrides=job_overrides,
                         mode=CloudRunMode.ASYNC,
-                        impersonation_chain=self.cloud_run_service_account or None,
+                        impersonation_chain=impersonation_chain,
                         preload=preload,
                         retry_on_failure=self.retry_on_failure,
                         **kwargs
@@ -336,7 +360,7 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
                         dataset=dataset,
                         source=self.source,
                         source_task_id=job_task.task_id,
-                        impersonation_chain=self.cloud_run_service_account or None,
+                        impersonation_chain=impersonation_chain,
                         preload=preload,
                         **kwargs
                     )
@@ -390,7 +414,7 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
                     region=self.cloud_run_job_region,
                     overrides=job_overrides,
                     mode=CloudRunMode.SYNC,
-                    impersonation_chain=self.cloud_run_service_account or None,
+                    impersonation_chain=impersonation_chain,
                     preload=preload,
                     retry_on_failure=self.retry_on_failure,
                     **kwargs
@@ -412,6 +436,10 @@ class GCloudRunJobCompletionSensor(StarlakeDatasetMixin, BashSensor):
                  impersonate_service_account: str=None, 
                  **kwargs
         ) -> None:
+        # issue #105 — a None param must not interpolate the literal string
+        # "None" into the gcloud commands (only direct construction hits it —
+        # the job always passes the fragment or "")
+        impersonate_service_account = impersonate_service_account or ""
         if retry_on_failure:
             kwargs.update({'retry_exit_code': 2})
             bash_command = (
@@ -419,7 +447,11 @@ class GCloudRunJobCompletionSensor(StarlakeDatasetMixin, BashSensor):
                 f"{{{{ task_instance.xcom_pull(key='return_value', task_ids='{source_task_id}') }}}} "
                 f"--region {cloud_run_job_region} "
                 f"--project {project_id} "
-                "--format='value(status.completionTime, status.cancelledCounts)' "
+                # issue #105 — the completion probe needs the impersonation
+                # fragment too: without it, credentials whose only Cloud Run
+                # grant is impersonation get a 403 on every poke and the
+                # sensor never completes
+                f"--format='value(status.completionTime, status.cancelledCounts)' {impersonate_service_account}"
                 "| sed 's/[[:blank:]]//g'`; "
                 "if [ -z \"$check_completion\" ]; then exit 2; else "
                 "check_status=`gcloud beta run jobs executions describe "

--- a/starlake-airflow/src/main/python/setup.py
+++ b/starlake-airflow/src/main/python/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 import os
 
-version = os.environ.get("PROJECT_VERSION", "0.6.7")
+version = os.environ.get("PROJECT_VERSION", "0.6.8")
 
 setup(name='starlake-airflow',
       version=version,

--- a/tests/airflow/test_airflow_cloud_run_impersonation.py
+++ b/tests/airflow/test_airflow_cloud_run_impersonation.py
@@ -1,0 +1,263 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Issue #104 — cloud_run impersonation has TWO consumers with TWO formats.
+
+``StarlakeAirflowCloudRunJob`` derives two values from
+``cloud_run_service_account``:
+
+- ``self.impersonate_service_account`` — the gcloud CLI fragment
+  ``--impersonate-service-account <email>`` (or ``""``), interpolated into
+  every gcloud/bash command string;
+- the bare email (``self.cloud_run_service_account or None``), passed as the
+  Google provider's ``impersonation_chain`` parameter on every python-operator
+  site.
+
+Before the fix, the CLI fragment was passed to BOTH consumers: any non-empty
+service account reached the Google auth layer as the literal string
+``--impersonate-service-account sa@...``, which it cannot use. Only
+``use_gcloud=false`` deployments with a service account were affected.
+
+Two layers, mirroring the 6.3/6.4/#99 suites:
+
+- provider-free source-scan pin (runs in CI, which installs NO google
+  provider): the fragment attribute no longer feeds any
+  ``impersonation_chain=`` site and the bare-email form is present at the
+  expected multiplicity;
+- provider-guarded content tests (skipped without
+  ``apache-airflow-providers-google``): constructed operators/sensors carry
+  the bare email (or ``None`` without a service account), and every gcloud
+  command string keeps the ``--impersonate-service-account`` flag.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.airflow.conftest import _AIRFLOW_TEST_MODULE_NAME, AIRFLOW_AVAILABLE
+
+pytestmark = pytest.mark.skipif(
+    not AIRFLOW_AVAILABLE,
+    reason="Requires Apache Airflow",
+)
+
+try:
+    import airflow.providers.google.cloud.operators.cloud_run  # noqa: F401
+    import google.cloud.run_v2  # noqa: F401
+    GOOGLE_AVAILABLE = True
+except Exception:
+    GOOGLE_AVAILABLE = False
+
+google_only = pytest.mark.skipif(
+    not GOOGLE_AVAILABLE,
+    reason="Requires apache-airflow-providers-google",
+)
+
+SA = "sa@test-project.iam.gserviceaccount.com"
+FLAG = f"--impersonate-service-account {SA}"
+
+CLOUD_RUN_OPTIONS = {
+    "cloud_run_job_name": "test-job",
+    "cloud_run_project_id": "test-project",
+    "cloud_run_job_region": "europe-west1",
+    "pre_load_strategy": "imported",
+}
+
+# the four core-injected sensor kwargs (6.5 preload-waiting construction)
+SENSOR_OPTIONS = {
+    "pre_load_sensor": "true",
+    "pre_load_poke_interval": "30",
+    "pre_load_timeout": "120",
+    "pre_load_sensor_soft_fail": "true",
+}
+
+
+def _dag():
+    from airflow import DAG
+    from datetime import datetime
+    return DAG(dag_id="test_cloud_run_impersonation", start_date=datetime(2024, 1, 1), schedule=None)
+
+
+def _make_job(extra_options=None, service_account=SA):
+    from ai.starlake.airflow.gcp import StarlakeAirflowCloudRunJob
+    options = dict(CLOUD_RUN_OPTIONS)
+    if service_account is not None:
+        options["cloud_run_service_account"] = service_account
+    options.update(extra_options or {})
+    return StarlakeAirflowCloudRunJob(
+        filename="test_airflow_cloud_run_impersonation.py",
+        module_name=_AIRFLOW_TEST_MODULE_NAME,
+        options=options,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Provider-free — source-scan pin (runs where no google provider installs)
+# ---------------------------------------------------------------------------
+
+class TestImpersonationSourcePin:
+    """CI installs no google provider, so the guarded content tests below
+    never run there — this source scan is the CI-runnable guard. It proves
+    text, not runtime behaviour (that is the guarded content tests' job); it
+    keeps the CLI fragment from creeping back onto an ``impersonation_chain=``
+    site (issue #104) and keeps the fragment construction the gcloud commands
+    interpolate from being wrongly removed."""
+
+    def _source(self):
+        import ai.starlake.airflow as pkg
+        path = os.path.join(os.path.dirname(pkg.__file__), "gcp", "starlake_airflow_cloud_run_job.py")
+        with open(path) as f:
+            return f.read()
+
+    def test_fragment_feeds_no_impersonation_chain_site(self):
+        assert "impersonation_chain=self.impersonate_service_account" not in self._source()
+
+    def test_bare_email_sites_present_at_expected_multiplicity(self):
+        # sync operator, async operator + completion sensor, and the 6.5
+        # preload-waiting `common` dict (which feeds both the deferrable
+        # operator and the sensor-flavor closure)
+        source = self._source()
+        assert source.count("impersonation_chain=self.cloud_run_service_account or None") == 4
+
+    def test_gcloud_fragment_construction_still_present(self):
+        assert 'f"--impersonate-service-account {self.cloud_run_service_account}"' in self._source()
+
+
+# ---------------------------------------------------------------------------
+# 2. Provider-guarded — python operators receive the bare email (AC1/AC2)
+# ---------------------------------------------------------------------------
+
+@google_only
+class TestImpersonationChainBareEmail:
+
+    def test_ctor_keeps_two_derived_values(self):
+        job = _make_job()
+        assert job.cloud_run_service_account == SA
+        assert job.impersonate_service_account == FLAG
+
+    def test_sync_api_operator(self):
+        job = _make_job({"use_gcloud": "false", "cloud_run_async": "false"})
+        with _dag():
+            task = job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        assert task.impersonation_chain == SA
+
+    def test_async_api_operator_and_completion_sensor(self):
+        job = _make_job({"use_gcloud": "false", "cloud_run_async": "true"})
+        with _dag() as dag:
+            job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        assert dag.get_task("load_customers_wait.load_customers").impersonation_chain == SA
+        assert dag.get_task("load_customers_wait.load_customers_check_completion").impersonation_chain == SA
+
+    def test_preload_waiting_deferrable_operator(self):
+        from ai.starlake.airflow.gcp.starlake_airflow_cloud_run_job import CloudRunJobOperator
+        job = _make_job(dict(SENSOR_OPTIONS, use_gcloud="false"))
+        with _dag():
+            task = job.sl_pre_load(domain="starbake", tables={"customers"})
+        assert isinstance(task, CloudRunJobOperator)
+        assert task.deferrable is True
+        assert task.impersonation_chain == SA
+
+    def test_preload_waiting_sensor_closure(self, monkeypatch):
+        """The sensor flavor builds an ad-hoc per-poke operator from the
+        `common` dict captured in the `submit_and_wait` closure — the bare
+        email must reach it too (same edit site as the deferrable flavor)."""
+        from airflow.providers.google.cloud.operators.cloud_run import CloudRunExecuteJobOperator
+        job = _make_job(dict(SENSOR_OPTIONS, use_gcloud="false", pre_load_deferrable="false"))
+        with _dag():
+            sensor = job.sl_pre_load(domain="starbake", tables={"customers"})
+        seen = {}
+
+        def capture(self, context):
+            seen["chain"] = self.impersonation_chain
+        monkeypatch.setattr(CloudRunExecuteJobOperator, "execute", capture)
+        sensor._submit_and_wait({}, {"container_overrides": [{"args": []}]})
+        assert seen["chain"] == SA
+
+    def test_no_service_account_is_none_not_empty_string(self):
+        """AC2 — ``None`` is the provider's documented "no impersonation"
+        value; the pin is ``is None`` so the contract stays explicit."""
+        job = _make_job({"use_gcloud": "false", "cloud_run_async": "false"}, service_account=None)
+        assert job.cloud_run_service_account == ""
+        assert job.impersonate_service_account == ""
+        with _dag():
+            task = job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        assert task.impersonation_chain is None
+
+    def test_no_service_account_async_and_deferrable_are_none(self):
+        job = _make_job({"use_gcloud": "false", "cloud_run_async": "true"}, service_account=None)
+        with _dag() as dag:
+            job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        assert dag.get_task("load_customers_wait.load_customers").impersonation_chain is None
+        assert dag.get_task("load_customers_wait.load_customers_check_completion").impersonation_chain is None
+        job = _make_job(dict(SENSOR_OPTIONS, use_gcloud="false"), service_account=None)
+        with _dag():
+            task = job.sl_pre_load(domain="starbake", tables={"customers"})
+        assert task.impersonation_chain is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Provider-guarded — gcloud command strings keep the CLI fragment (AC3)
+# ---------------------------------------------------------------------------
+
+@google_only
+class TestGcloudFragmentUnchanged:
+
+    def test_sync_command_keeps_flag(self):
+        job = _make_job({"use_gcloud": "true", "cloud_run_async": "false"})
+        with _dag():
+            task = job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        assert FLAG in task.bash_command
+
+    def test_async_submission_status_and_sensor_keep_flag(self):
+        job = _make_job({"use_gcloud": "true", "cloud_run_async": "true"})
+        with _dag() as dag:
+            job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        assert FLAG in dag.get_task("load_customers_wait.load_customers").bash_command
+        assert FLAG in dag.get_task("load_customers_wait.load_customers_check_completion").bash_command
+        assert FLAG in dag.get_task("load_customers_wait.load_customers_get_completion_status").bash_command
+
+    def test_async_retry_on_failure_sensor_keeps_flag(self):
+        job = _make_job({"use_gcloud": "true", "cloud_run_async": "true", "retry_on_failure": "true"})
+        with _dag() as dag:
+            job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        assert FLAG in dag.get_task("load_customers_wait.load_customers_check_completion").bash_command
+
+    def test_preload_waiting_gcloud_sensor_keeps_flag(self):
+        job = _make_job(dict(SENSOR_OPTIONS, use_gcloud="true"))
+        with _dag():
+            task = job.sl_pre_load(domain="starbake", tables={"customers"})
+        assert FLAG in task.bash_command
+
+    def test_no_service_account_no_flag_anywhere(self):
+        job = _make_job({"use_gcloud": "true", "cloud_run_async": "false"}, service_account=None)
+        with _dag():
+            task = job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        assert "--impersonate-service-account" not in task.bash_command
+        job = _make_job({"use_gcloud": "true", "cloud_run_async": "true"}, service_account=None)
+        with _dag() as dag:
+            job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        for task_id in (
+            "load_customers_wait.load_customers",
+            "load_customers_wait.load_customers_check_completion",
+            "load_customers_wait.load_customers_get_completion_status",
+        ):
+            assert "--impersonate-service-account" not in dag.get_task(task_id).bash_command, task_id
+        job = _make_job(dict(SENSOR_OPTIONS, use_gcloud="true"), service_account=None)
+        with _dag():
+            task = job.sl_pre_load(domain="starbake", tables={"customers"})
+        assert "--impersonate-service-account" not in task.bash_command

--- a/tests/airflow/test_airflow_cloud_run_impersonation.py
+++ b/tests/airflow/test_airflow_cloud_run_impersonation.py
@@ -128,14 +128,25 @@ class TestImpersonationSourcePin:
         assert "impersonation_chain=self.impersonate_service_account" not in self._source()
 
     def test_bare_email_sites_present_at_expected_multiplicity(self):
-        # sync operator, async operator + completion sensor, and the 6.5
-        # preload-waiting `common` dict (which feeds both the deferrable
-        # operator and the sensor-flavor closure)
+        # four sl_job sites — sync operator, async operator + completion
+        # sensor, and the 6.5 preload-waiting `common` dict (which feeds both
+        # the deferrable operator and the sensor-flavor closure) — all consume
+        # the once-per-call resolution (issue #105: explicit kwarg wins over
+        # the derived bare email); the fifth match is CloudRunJobOperator's
+        # ctor pass-through to the provider operator
         source = self._source()
-        assert source.count("impersonation_chain=self.cloud_run_service_account or None") == 4
+        assert source.count("impersonation_chain=impersonation_chain,") == 5
+        assert "kwargs.pop('impersonation_chain', self.cloud_run_service_account or None)" in source
 
     def test_gcloud_fragment_construction_still_present(self):
         assert 'f"--impersonate-service-account {self.cloud_run_service_account}"' in self._source()
+
+    def test_completion_probes_all_carry_the_fragment(self):
+        """Issue #105 — the retry-flavor sensor's completionTime probe used to
+        omit the fragment. All three `executions describe` probe sites in
+        GCloudRunJobCompletionSensor now interpolate it (fragment placeholder
+        right after the --format value, before the sed pipe)."""
+        assert self._source().count("cancelledCounts)' {impersonate_service_account}") == 3
 
 
 # ---------------------------------------------------------------------------
@@ -198,6 +209,86 @@ class TestImpersonationChainBareEmail:
             task = job.sl_load(task_id="load_customers", domain="starbake", table="customers")
         assert task.impersonation_chain is None
 
+    def test_explicit_chain_kwarg_wins_on_sync_api_path(self):
+        """Issue #105 — an explicit impersonation_chain kwarg (here a
+        delegation chain, valid for the provider) used to raise TypeError
+        ('got multiple values') at DAG parse; it now wins over the derived
+        bare email."""
+        chain = ["sa1@p.iam.gserviceaccount.com", "sa2@p.iam.gserviceaccount.com"]
+        job = _make_job({"use_gcloud": "false", "cloud_run_async": "false"})
+        with _dag():
+            task = job.sl_load(
+                task_id="load_customers", domain="starbake", table="customers",
+                impersonation_chain=chain,
+            )
+        assert task.impersonation_chain == chain
+
+    def test_explicit_chain_kwarg_reaches_async_operator_and_sensor(self):
+        chain = ["sa1@p.iam.gserviceaccount.com", "sa2@p.iam.gserviceaccount.com"]
+        job = _make_job({"use_gcloud": "false", "cloud_run_async": "true"})
+        with _dag() as dag:
+            job.sl_load(
+                task_id="load_customers", domain="starbake", table="customers",
+                impersonation_chain=chain,
+            )
+        assert dag.get_task("load_customers_wait.load_customers").impersonation_chain == chain
+        assert dag.get_task("load_customers_wait.load_customers_check_completion").impersonation_chain == chain
+
+    def test_explicit_chain_kwarg_reaches_preload_deferrable(self):
+        chain = ["sa1@p.iam.gserviceaccount.com", "sa2@p.iam.gserviceaccount.com"]
+        job = _make_job(dict(SENSOR_OPTIONS, use_gcloud="false"))
+        with _dag():
+            task = job.sl_pre_load(domain="starbake", tables={"customers"}, impersonation_chain=chain)
+        assert task.impersonation_chain == chain
+
+    def test_explicit_none_kwarg_opts_out_of_impersonation(self):
+        """Explicit ``impersonation_chain=None`` is an intentional opt-out
+        (the provider's own "no impersonation" value) — it wins over the
+        configured service account, like any other explicit kwarg."""
+        job = _make_job({"use_gcloud": "false", "cloud_run_async": "false"})
+        with _dag():
+            task = job.sl_load(
+                task_id="load_customers", domain="starbake", table="customers",
+                impersonation_chain=None,
+            )
+        assert task.impersonation_chain is None
+
+    def test_explicit_chain_kwarg_reaches_preload_sensor_closure(self, monkeypatch):
+        from airflow.providers.google.cloud.operators.cloud_run import CloudRunExecuteJobOperator
+        chain = ["sa1@p.iam.gserviceaccount.com", "sa2@p.iam.gserviceaccount.com"]
+        job = _make_job(dict(SENSOR_OPTIONS, use_gcloud="false", pre_load_deferrable="false"))
+        with _dag():
+            sensor = job.sl_pre_load(domain="starbake", tables={"customers"}, impersonation_chain=chain)
+        seen = {}
+
+        def capture(self, context):
+            seen["chain"] = self.impersonation_chain
+        monkeypatch.setattr(CloudRunExecuteJobOperator, "execute", capture)
+        sensor._submit_and_wait({}, {"container_overrides": [{"args": []}]})
+        assert seen["chain"] == chain
+
+    @pytest.mark.parametrize("cloud_run_async", ["false", "true"])
+    def test_explicit_chain_kwarg_still_rejected_on_gcloud_paths(self, cloud_run_async):
+        """A chain has no gcloud-fragment equivalent — the kwarg must keep
+        failing loudly (the operator ctor rejects it by name) rather than
+        being silently swallowed, on every gcloud branch."""
+        job = _make_job({"use_gcloud": "true", "cloud_run_async": cloud_run_async})
+        with pytest.raises(Exception, match="impersonation_chain"):
+            with _dag():
+                job.sl_load(
+                    task_id="load_customers", domain="starbake", table="customers",
+                    impersonation_chain=["sa1@p.iam.gserviceaccount.com"],
+                )
+
+    def test_explicit_chain_kwarg_still_rejected_on_gcloud_preload_sensor(self):
+        job = _make_job(dict(SENSOR_OPTIONS, use_gcloud="true"))
+        with pytest.raises(Exception, match="impersonation_chain"):
+            with _dag():
+                job.sl_pre_load(
+                    domain="starbake", tables={"customers"},
+                    impersonation_chain=["sa1@p.iam.gserviceaccount.com"],
+                )
+
     def test_no_service_account_async_and_deferrable_are_none(self):
         job = _make_job({"use_gcloud": "false", "cloud_run_async": "true"}, service_account=None)
         with _dag() as dag:
@@ -231,11 +322,21 @@ class TestGcloudFragmentUnchanged:
         assert FLAG in dag.get_task("load_customers_wait.load_customers_check_completion").bash_command
         assert FLAG in dag.get_task("load_customers_wait.load_customers_get_completion_status").bash_command
 
-    def test_async_retry_on_failure_sensor_keeps_flag(self):
+    def test_async_retry_on_failure_sensor_keeps_flag_on_both_probes(self):
+        """Issue #105 — the retry flavor runs TWO `executions describe` probes
+        (completionTime then failedCount); the first used to omit the fragment,
+        so credentials whose only Cloud Run grant is impersonation got a 403 on
+        every poke. Per-probe pin: the flag appears exactly twice."""
         job = _make_job({"use_gcloud": "true", "cloud_run_async": "true", "retry_on_failure": "true"})
         with _dag() as dag:
             job.sl_load(task_id="load_customers", domain="starbake", table="customers")
-        assert FLAG in dag.get_task("load_customers_wait.load_customers_check_completion").bash_command
+        assert dag.get_task("load_customers_wait.load_customers_check_completion").bash_command.count(FLAG) == 2
+
+    def test_async_non_retry_sensor_single_probe_keeps_flag(self):
+        job = _make_job({"use_gcloud": "true", "cloud_run_async": "true"})
+        with _dag() as dag:
+            job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        assert dag.get_task("load_customers_wait.load_customers_check_completion").bash_command.count(FLAG) == 1
 
     def test_preload_waiting_gcloud_sensor_keeps_flag(self):
         job = _make_job(dict(SENSOR_OPTIONS, use_gcloud="true"))
@@ -261,3 +362,46 @@ class TestGcloudFragmentUnchanged:
         with _dag():
             task = job.sl_pre_load(domain="starbake", tables={"customers"})
         assert "--impersonate-service-account" not in task.bash_command
+
+
+# ---------------------------------------------------------------------------
+# 4. Provider-guarded — input hygiene on the service-account option (#105)
+# ---------------------------------------------------------------------------
+
+@google_only
+class TestServiceAccountHygiene:
+
+    def test_padded_service_account_is_stripped(self):
+        job = _make_job(service_account=f"  {SA}  ")
+        assert job.cloud_run_service_account == SA
+        assert job.impersonate_service_account == FLAG
+
+    def test_whitespace_only_service_account_means_no_impersonation(self):
+        job = _make_job({"use_gcloud": "false", "cloud_run_async": "false"}, service_account="   ")
+        assert job.cloud_run_service_account == ""
+        assert job.impersonate_service_account == ""
+        with _dag():
+            task = job.sl_load(task_id="load_customers", domain="starbake", table="customers")
+        assert task.impersonation_chain is None
+
+    def test_sequence_service_account_rejected_at_construction(self):
+        """A sequence would render its Python repr into the gcloud fragment —
+        rejected up front; delegation chains go through the per-call
+        impersonation_chain kwarg (python-operator paths)."""
+        with pytest.raises(ValueError, match="cloud_run_service_account"):
+            _make_job(service_account=["sa1@p.iam.gserviceaccount.com", "sa2@p.iam.gserviceaccount.com"])
+
+    def test_direct_sensor_construction_without_param_has_no_literal_none(self):
+        from ai.starlake.airflow.gcp.starlake_airflow_cloud_run_job import GCloudRunJobCompletionSensor
+        for retry_on_failure in (False, True):
+            with _dag():
+                sensor = GCloudRunJobCompletionSensor(
+                    task_id=f"probe_{retry_on_failure}",
+                    dataset=None,
+                    source=None,
+                    project_id="test-project",
+                    cloud_run_job_region="europe-west1",
+                    source_task_id="job",
+                    retry_on_failure=retry_on_failure,
+                )
+            assert "None" not in sensor.bash_command, retry_on_failure


### PR DESCRIPTION
Fixes #104. Fixes #105.

## Problem (#104)

`StarlakeAirflowCloudRunJob` built `self.impersonate_service_account` as a gcloud CLI fragment (`--impersonate-service-account <email>`, or `""`) and passed that same attribute both into gcloud command-string interpolations (correct) and as the Google provider's `impersonation_chain` parameter (wrong — the auth layer expects a bare email or a sequence of emails, and cannot use the fragment). Only deployments setting `cloud_run_service_account` AND using `use_gcloud=false` were affected.

## Fix (#104, commit 3cd189a)

Four `impersonation_chain=` sites now pass the bare service-account email:

- the sync `CloudRunJobOperator`;
- the async `CloudRunJobOperator` and its `CloudRunJobCompletionSensor`;
- the pre-load waiting `common` dict, which transitively fixes both python flavors (the deferrable operator and the sensor-flavor `submit_and_wait` closure).

`self.impersonate_service_account` keeps its name and CLI-fragment semantics — the five gcloud/bash interpolation sites are byte-identical (no rename, no breaking change). Without a service account the provider now receives `None` instead of `""`.

## Follow-ups (#105, commit 74a28cf)

- The `retry_on_failure` completion sensor's first `executions describe` probe (completionTime) now interpolates the impersonation fragment like the other two probe sites — credentials whose only Cloud Run grant is impersonation no longer 403 on every poke.
- An explicit `impersonation_chain` kwarg (bare email, delegation chain, or `None` as opt-out) is resolved once per `sl_job` call on the python-operator paths and wins over the derived bare email — it used to collide with the explicit ctor kwarg (`TypeError` at DAG parse). The gcloud paths keep rejecting it loudly (a chain has no fragment equivalent).
- Option hygiene: `cloud_run_service_account` is stripped and must be a single email string (NFR11-shaped `ValueError` on sequences or comma/space-joined chains); a `None` `impersonate_service_account` param on the completion sensor no longer interpolates a literal `None`.

## Tests

New `tests/airflow/test_airflow_cloud_run_impersonation.py` (29 tests), two layers (same pattern as the #92/#95/#99 suites):

- provider-free source-scan pins (CI-runnable): the fragment feeds no `impersonation_chain=` site, the once-per-call resolution is present, all three `GCloudRunJobCompletionSensor` probes carry the fragment placeholder, the fragment construction is still present;
- `google_only` construction tests: bare email on every python-operator site (including the pre-load waiting deferrable operator and sensor closure), `is None` without a service account, explicit-kwarg precedence on every python path, loud gcloud rejection on all three gcloud branches, per-probe flag counts, flag absence everywhere without a service account, and the hygiene contract.

Results: A2 (airflow 2.10.5 + google provider) **389 passed** non-runtime suite; A3 (3.3.0, provider-free) **274 passed / 115 provider-guarded skips**.

starlake-airflow `0.6.7` → `0.6.8` (pom.xml + setup.py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
