### PR TITLE
fix(dagster): stop mutating the op-closure arguments list (shell, cloud_run, fargate)

### DIFF
--- a/starlake-dagster/ARCHITECTURE.md
+++ b/starlake-dagster/ARCHITECTURE.md
@@ -190,6 +190,7 @@ Base job factory. Unlike Airflow, does NOT override `get_context_var()` (no Dags
 - `_sl_resolve_pre_load_poke(kwargs)` — classmethod called first by EVERY variant's `sl_job` (shell, cloud_run, dataproc, fargate): pops the four `pre_load_*` sensor kwargs unconditionally (a popped-but-false flag never leaks into an op) and returns `None` (off) or a `PreLoadPoke(poke_interval, timeout, soft_fail)` after a strict NFR11 re-parse (covers direct `sl_job` calls — `bool('false')` would silently enable sensor mode). Replaces the story 6.2 cloud rejection `_reject_pre_load_sensor_kwargs` (story 6.7, issue #94)
 - `_sl_pre_load_poke_loop(context, run_once, is_success, poke, command_label)` — classmethod implementing the shared in-op wall-clock poke loop; `time.monotonic()`/`time.sleep()` are module-attribute calls (test seam)
 - `dummy_op()` — `@op` yielding `Output(value=task_id)` + `AssetMaterialization` per event
+- All variants' op bodies read the captured `arguments` list WITHOUT mutating it (issue #111 — applies to every task type, not just sensor mode): a `RetryPolicy` re-execution re-submits the same command, and the fargate helper — which shares the very same list and joins it lazily — keeps its command verb
 
 #### Pre-load sensor mode (story 6.2, issue #86; extended to the cloud variants by story 6.7, issue #94)
 

--- a/starlake-dagster/pom.xml
+++ b/starlake-dagster/pom.xml
@@ -14,7 +14,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>starlake-dagster</artifactId>
-    <version>0.5.4</version>
+    <version>0.5.5</version>
     <packaging>jar</packaging>
 
 </project>

--- a/starlake-dagster/src/main/python/ai/starlake/dagster/aws/starlake_dagster_fargate_job.py
+++ b/starlake-dagster/src/main/python/ai/starlake/dagster/aws/starlake_dagster_fargate_job.py
@@ -118,8 +118,13 @@ class StarlakeDagsterFargateJob(StarlakeDagsterJob):
             from ai.starlake.common import sl_timestamp_format
             logical_datetime: datetime = StarlakeDagsterUtils.get_logical_datetime(context, config).strftime(sl_timestamp_format)
             tmp_arguments.append(f"\'{logical_datetime}\'")
-            command = arguments.pop(0)
-            command_with_arguments = [command] + tmp_arguments + arguments
+            # read WITHOUT mutating (issue #111): `arguments` is the closure
+            # list — a RetryPolicy re-execution of this op function would
+            # otherwise pop the next element as the command
+            # (and the fargate helper JOINS this same list lazily: popping the
+            # verb corrupted even the FIRST attempt of non-transform tasks)
+            command = arguments[0]
+            command_with_arguments = [command] + tmp_arguments + arguments[1:]
 
             if transform:
                 opts = command_with_arguments[-1].split(",")

--- a/starlake-dagster/src/main/python/ai/starlake/dagster/gcp/starlake_dagster_cloud_run_job.py
+++ b/starlake-dagster/src/main/python/ai/starlake/dagster/gcp/starlake_dagster_cloud_run_job.py
@@ -135,8 +135,11 @@ class StarlakeDagsterCloudRunJob(StarlakeDagsterJob):
             from ai.starlake.common import sl_timestamp_format
             logical_datetime: datetime = StarlakeDagsterUtils.get_logical_datetime(context, config).strftime(sl_timestamp_format)
             tmp_arguments.append(f"\'{logical_datetime}\'")
-            command = arguments.pop(0)
-            command_with_arguments = [command] + tmp_arguments + arguments
+            # read WITHOUT mutating (issue #111): `arguments` is the closure
+            # list — a RetryPolicy re-execution of this op function would
+            # otherwise pop the next element as the command
+            command = arguments[0]
+            command_with_arguments = [command] + tmp_arguments + arguments[1:]
 
             if transform:
                 opts = command_with_arguments[-1].split(",")

--- a/starlake-dagster/src/main/python/ai/starlake/dagster/shell/starlake_dagster_shell_job.py
+++ b/starlake-dagster/src/main/python/ai/starlake/dagster/shell/starlake_dagster_shell_job.py
@@ -135,12 +135,15 @@ class StarlakeDagsterShellJob(StarlakeDagsterJob):
             from datetime import datetime
             from ai.starlake.common import sl_timestamp_format
             logical_datetime: datetime = StarlakeDagsterUtils.get_logical_datetime(context, config).strftime(sl_timestamp_format)
-            command = arguments.pop(0)
+            # read WITHOUT mutating (issue #111): `arguments` is the closure
+            # list — a RetryPolicy re-execution of this op function would
+            # otherwise pop the next element as the command
+            command = arguments[0]
             if task_type is not None and (task_type == TaskType.LOAD or task_type == TaskType.TRANSFORM):
                 tmp_arguments = ["--scheduledDate", f"\'{logical_datetime}\'"]
-                command_with_arguments = [command] + tmp_arguments + arguments
+                command_with_arguments = [command] + tmp_arguments + arguments[1:]
             else:
-                command_with_arguments = [command] + arguments
+                command_with_arguments = [command] + arguments[1:]
 
             if transform:
                 opts = command_with_arguments[-1].split(",")

--- a/starlake-dagster/src/main/python/setup.py
+++ b/starlake-dagster/src/main/python/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 import os
 
-version = os.environ.get("PROJECT_VERSION", "0.5.4")
+version = os.environ.get("PROJECT_VERSION", "0.5.5")
 
 setup(name='starlake-dagster',
       version=version,

--- a/tests/dagster/test_dagster_retry_arguments.py
+++ b/tests/dagster/test_dagster_retry_arguments.py
@@ -1,0 +1,206 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Story 6.9 (issue #111) — op bodies must not mutate the closure arguments.
+
+``command = arguments.pop(0)`` mutated the list captured in the op closure,
+so a RetryPolicy re-execution popped the NEXT argument as the command verb —
+a retried attempt could never succeed.  On Fargate it was worse: the helper
+holds the SAME list object and joins it LAZILY (``command``/``overrides``),
+so even the FIRST attempt of a non-transform task shipped a container
+command missing its verb.  The dataproc leg was fixed in story 6.8; this
+story fixes shell, cloud_run and fargate with the same non-mutating read.
+
+All three variants are importable in the CI leg (no dagster-gcp needed).
+Retry tests use ``retry_delay: "1"`` — Dagster's retry delay sleeps for
+real (~1s per retry).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from tests.dagster.conftest import _DAGSTER_TEST_MODULE_NAME
+from tests.dagster.test_dagster_sl_pre_load_cloud_sensor import (
+    CLOUD_RUN_OPTIONS,
+    FARGATE_OPTIONS,
+    PRELOAD_TASK_ID,
+    _execute,
+)
+
+TASK_ID = PRELOAD_TASK_ID  # reuse the RUN_CONFIG op name from the helpers
+
+RETRY_OPTIONS = {"retry_delay": "1"}
+
+
+def _make_load_node(job):
+    return job.sl_load(
+        task_id=TASK_ID,
+        domain="starbake",
+        table="customers",
+        retries=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Shell — identical command across retry attempts
+# ---------------------------------------------------------------------------
+
+class TestShellRetryArguments:
+
+    def _make_job(self, options: dict):
+        from ai.starlake.dagster.shell import StarlakeDagsterShellJob
+        return StarlakeDagsterShellJob(
+            filename="test_dagster_retry_arguments.py",
+            module_name=_DAGSTER_TEST_MODULE_NAME,
+            options=options,
+        )
+
+    def test_retry_reexecutes_identical_command(self, monkeypatch):
+        import ai.starlake.dagster.shell.starlake_dagster_shell_job as mod
+
+        calls = []
+
+        def fake_execute(shell_command, **kwargs):
+            calls.append(shell_command)
+            return ("out", 1 if len(calls) == 1 else 0)
+
+        monkeypatch.setattr(mod, "execute_shell_command", fake_execute)
+
+        node = _make_load_node(self._make_job(dict(RETRY_OPTIONS)))
+        result = _execute(node, raise_on_error=False)
+
+        assert result.success
+        assert len(calls) == 2
+        # the closure list must not be mutated: attempt 2 re-runs the SAME
+        # command, verb included (pop(0) used to shift the next arg into the
+        # verb position)
+        assert calls[0] == calls[1]
+        # positional pin: the verb is the first argument after the starlake
+        # executable (a substring match could not catch duplication/shifting)
+        assert calls[0].split()[1] == "load"
+
+
+# ---------------------------------------------------------------------------
+# 2. Cloud Run — identical gcloud execution across retry attempts
+# ---------------------------------------------------------------------------
+
+class TestCloudRunRetryArguments:
+
+    def _make_job(self, options: dict):
+        from ai.starlake.dagster.gcp import StarlakeDagsterCloudRunJob
+        return StarlakeDagsterCloudRunJob(
+            filename="test_dagster_retry_arguments.py",
+            module_name=_DAGSTER_TEST_MODULE_NAME,
+            options={**CLOUD_RUN_OPTIONS, **options},
+        )
+
+    def test_retry_reexecutes_identical_command(self, monkeypatch):
+        import ai.starlake.dagster.gcp.starlake_dagster_cloud_run_job as mod
+
+        calls = []
+
+        def fake_execute(shell_command, **kwargs):
+            calls.append(shell_command)
+            return ("out", 1 if len(calls) == 1 else 0)
+
+        monkeypatch.setattr(mod, "execute_shell_command", fake_execute)
+
+        node = _make_load_node(self._make_job(dict(RETRY_OPTIONS)))
+        result = _execute(node, raise_on_error=False)
+
+        assert result.success
+        assert len(calls) == 2
+        assert calls[0] == calls[1]
+        # positional pin: the gcloud --args fragment starts with the verb
+        # (its ^ ^ prefix declares the space separator)
+        assert '--args "^ ^load ' in calls[0]
+
+
+# ---------------------------------------------------------------------------
+# 3. Fargate — helper arguments intact (verb included) on EVERY attempt
+# ---------------------------------------------------------------------------
+
+class TestFargateRetryArguments:
+
+    def _make_job(self, options: dict):
+        from ai.starlake.dagster.aws import StarlakeDagsterFargateJob
+        return StarlakeDagsterFargateJob(
+            filename="test_dagster_retry_arguments.py",
+            module_name=_DAGSTER_TEST_MODULE_NAME,
+            options={**FARGATE_OPTIONS, **options},
+        )
+
+    def _patch_fargate(self, monkeypatch, return_codes):
+        import ai.starlake.dagster.aws.starlake_dagster_fargate_job as mod
+        from ai.starlake.aws import StarlakeFargateHelper
+
+        seen_arguments = []
+        calls = []
+
+        def fake_generate_script(self):
+            # the helper joins self.arguments LAZILY — snapshot what the
+            # generated script would actually ship
+            seen_arguments.append(list(self.arguments))
+            fd, path = tempfile.mkstemp(suffix=".sh", prefix="sl_fargate_retry_")
+            os.close(fd)
+            return path
+
+        def fake_execute(shell_script_path, **kwargs):
+            calls.append(shell_script_path)
+            code = return_codes[min(len(calls), len(return_codes)) - 1]
+            return ("out", code)
+
+        monkeypatch.setattr(
+            StarlakeFargateHelper, "generate_script", fake_generate_script
+        )
+        monkeypatch.setattr(mod, "execute_shell_script", fake_execute)
+        return seen_arguments, calls
+
+    def test_first_attempt_container_command_keeps_verb(self, monkeypatch):
+        # issue #111 fargate facet: the helper shares the op's arguments
+        # list, so pop(0) dropped the verb from the container command on the
+        # VERY FIRST attempt of any non-transform task
+        seen_arguments, calls = self._patch_fargate(monkeypatch, [0])
+        job = self._make_job({})
+        node = job.sl_load(
+            task_id=TASK_ID,
+            domain="starbake",
+            table="customers",
+            retries=0,
+        )
+        result = _execute(node)
+
+        assert result.success
+        assert len(calls) == 1
+        assert len(seen_arguments) == 1
+        assert seen_arguments[0][0] == "load"
+        assert seen_arguments[0].count("load") == 1
+
+    def test_retry_reexecutes_identical_arguments(self, monkeypatch):
+        seen_arguments, calls = self._patch_fargate(monkeypatch, [1, 0])
+        node = _make_load_node(self._make_job(dict(RETRY_OPTIONS)))
+        result = _execute(node, raise_on_error=False)
+
+        assert result.success
+        assert len(calls) == 2
+        assert len(seen_arguments) == 2
+        assert seen_arguments[0] == seen_arguments[1]
+        assert seen_arguments[0][0] == "load"
+        assert seen_arguments[0].count("load") == 1


### PR DESCRIPTION
Closes #111 · starlake-dagster **0.5.4 → 0.5.5**

> **MERGE NOTE — stacked PR**: based on `feature/6.8` (PR #112). Merge #112 first, then retarget this PR to `main`. The 0.5.5 bump assumes 0.5.4 ships with #112.

## What

`command = arguments.pop(0)` in the shell, cloud_run and fargate op bodies mutated the list captured in the op **closure**:

- **All variants**: a `RetryPolicy` re-execution popped the NEXT argument as the command verb — with `retries >= 1` (the default for non-preload tasks) a retried attempt could never succeed. Now that #109/#111-dataproc made Dagster retries real, this mattered.
- **Fargate (worse)**: `StarlakeFargateHelper` holds the SAME list object and joins it **lazily** (`command` / `overrides.containerOverrides[0].command`), so even the **first attempt** of any non-transform task shipped a container command missing its leading verb.

Fix: read without mutating (`arguments[0]` + `arguments[1:]`), completing what the 6.8 dataproc leg started. No other behavior changes (transform branches, options merging, poke loops untouched).

## Tests

New `tests/dagster/test_dagster_retry_arguments.py` — **CI-runnable** (all three variants import without dagster-gcp):

- shell / cloud_run: `retries=1`, first attempt fails → both executions byte-identical, with **positional** verb pins (`split()[1] == "load"`; gcloud `--args "^ ^load …"` fragment).
- fargate: the helper's shipped arguments snapshot at `generate_script()` time — verb present and unique on attempt 1 (`retries=0`), identical across retry attempts.

Suites: provider venv **214 passed, 1 skipped** · CI-equivalent venv **196 passed, 19 skipped** (dataproc skips as designed).

## Pre-existing bugs surfaced by the review (filed, deliberately not fixed here)

- **#113** — fargate (and dataproc) non-transform tasks never ship `--scheduledDate` to the container: the scheduledDate-carrying vector only reaches the helper/`job_details` in the transform branch. Previously masked on fargate because the path was wholly broken (missing verb); this PR un-masks it — first attempts now succeed but at container-default date.
- **#114** — fargate transform branch crashes (`environment.update` on a `List[dict]`), and cloud transforms without `--options` comma-merge options into the transform name.
- **#115** — `assets.append` in every op body is the same closure-mutation bug class: duplicate `AssetMaterialization`s on retried attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
