### PR TITLE
fix(airflow): support Airflow >= 2.5 for the data-aware round-trip (#125)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # These variables are loaded by conftest.py and can be overridden
 # by system environment variables.
 
-SL_VERSION=1.5.11
+SL_VERSION=1.5.16
 SL_ENV=DUCKDB
 # Secondary Starlake CLI version for NFR7 version-tolerance tests.
 # Install with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ env:
   #   orchestrator_version → pip pin for the orchestrator ("-" = none; the
   #                          snowflake SDK comes via install_requires)
   #   companion            → extra coupled pin (dagster-shell tracks dagster)
+  #   python_version       → per-leg Python override (optional; falls back to
+  #                          env.PYTHON_VERSION). Airflow 2.5.x predates
+  #                          Python 3.11 support, so its leg pins 3.10.
   #   tests                → pytest path(s) for the leg
   #   enabled              → spawn switch
   # tests/airflow/ is a DUAL-VERSION suite (compat layer + commit b4ab4da):
@@ -49,6 +52,8 @@ env:
   TEST_MATRIX: >-
     [
       {"name":"orchestration","module":"orchestration","orchestrator_version":"-","tests":"tests/orchestration/ tests/shared/","enabled":true},
+      {"name":"airflow-2.5.3","module":"airflow","orchestrator_version":"2.5.3","python_version":"3.10","tests":"tests/airflow/","enabled":true},
+      {"name":"airflow-2.9.3","module":"airflow","orchestrator_version":"2.9.3","tests":"tests/airflow/","enabled":true},
       {"name":"airflow-2.10.5","module":"airflow","orchestrator_version":"2.10.5","tests":"tests/airflow/","enabled":true},
       {"name":"airflow-3.3.0","module":"airflow","orchestrator_version":"3.3.0","tests":"tests/airflow/","enabled":true},
       {"name":"dagster-1.9.13","module":"dagster","orchestrator_version":"1.9.13","companion":"dagster-shell==0.25.13","tests":"tests/dagster/","enabled":true},
@@ -248,7 +253,7 @@ jobs:
         run: SL_VERSION=${{ env.SL_VERSION_SECONDARY }} "$HOME/starlake-${{ env.SL_VERSION_SECONDARY }}/starlake" --version | grep -F "${{ env.SL_VERSION_SECONDARY }}"
 
       - name: Create virtual environment
-        run: uv venv --python ${{ env.PYTHON_VERSION }}
+        run: uv venv --python ${{ matrix.python_version || env.PYTHON_VERSION }}
 
       - name: Install test dependencies
         run: uv pip install -r pyproject.toml --extra test
@@ -287,7 +292,7 @@ jobs:
               ;;
             airflow)
               uv pip install "apache-airflow==${{ matrix.orchestrator_version }}" \
-                --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${{ matrix.orchestrator_version }}/constraints-${{ env.PYTHON_VERSION }}.txt"
+                --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${{ matrix.orchestrator_version }}/constraints-${{ matrix.python_version || env.PYTHON_VERSION }}.txt"
               uv pip install starlake-airflow/src/main/python/
               ;;
             dagster)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   JAVA_VERSION: 17
   PYTHON_VERSION: "3.11"
-  SL_VERSION: "1.5.11"
+  SL_VERSION: "1.5.16"
   # Secondary CLI for the NFR7 version-tolerance test (orchestration leg only).
   SL_VERSION_SECONDARY: "1.5.15"
   SL_ENV: DUCKDB
@@ -294,6 +294,13 @@ jobs:
               uv pip install "apache-airflow==${{ matrix.orchestrator_version }}" \
                 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${{ matrix.orchestrator_version }}/constraints-${{ matrix.python_version || env.PYTHON_VERSION }}.txt"
               uv pip install starlake-airflow/src/main/python/
+              # The shared "Install test dependencies" step pulls an unpinned
+              # (latest) pytest; the Airflow constraint above then pins an older
+              # test ecosystem (e.g. 2.5.3 -> pluggy 1.0.0, packaging 21.3) that
+              # the latest pytest rejects at import. Re-resolve pytest under the
+              # SAME constraint so the test runner matches the leg's environment.
+              uv pip install pytest \
+                --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${{ matrix.orchestrator_version }}/constraints-${{ matrix.python_version || env.PYTHON_VERSION }}.txt"
               ;;
             dagster)
               uv pip install "dagster==${{ matrix.orchestrator_version }}" "${{ matrix.companion }}"

--- a/starlake-airflow/README.md
+++ b/starlake-airflow/README.md
@@ -12,7 +12,7 @@ Before installing starlake-airflow, ensure the following minimum versions are in
 
 - starlake: 1.5.7 or higher
 - Python: 3.8 or higher
-- Apache Airflow: 2.10.0 or higher
+- Apache Airflow: 2.5.0 or higher (3.x supported). Airflow 2.5–2.9 are supported for the full data-aware round-trip, with some advanced features gated to higher versions — see [Airflow version compatibility](#airflow-version-compatibility).
 
 ### Airflow API Configuration
 
@@ -307,10 +307,24 @@ In conjunction with the starlake dag generation, the `outlets` property can be u
 
 ### Airflow version compatibility
 
-The library detects the installed Airflow version and adapts its behavior:
+The library supports **Apache Airflow 2.5.0 → 3.x** from a single codebase. It detects the installed Airflow version at runtime and adapts its behavior, so the full data-aware round-trip (a load DAG emits dataset outlets carrying Starlake's runtime metadata; a transform DAG is triggered by them and reads that metadata) works across the whole range. Some capabilities that depend on newer Airflow APIs are gated by version and degrade gracefully below their floor:
 
-- **`supports_inlet_events()`** -- returns `True` for Airflow >= 2.10.0, enabling inlet event support for dataset readiness validation via `ShortCircuitOperator` in the `start_op()`.
-- **`supports_assets()`** -- returns `True` for Airflow >= 3.0.0, enabling asset-based scheduling.
+| Capability | Airflow floor | Below the floor |
+| --- | --- | --- |
+| Datasets (outlets / triggering) | 2.4 (2.5 for `triggering_dataset_events`) | n/a — 2.5 is the supported floor |
+| Outlet `extra` carried onto the emitted event (`supports_inlet_events()`) | 2.10 (native `outlet_events` accessor) | forwarded by a thin `DatasetManager.register_dataset_change` wrapper so the runtime `extra` is not dropped (issue #125) |
+| Conditional dataset scheduling — `DatasetAny`/`DatasetAll` via `\|`/`&` (`supports_dataset_conditions()`) | 2.9 | `ALL` uses a native flat-list schedule; `ANY` degrades to `ALL` (flat list) with a logged warning, since OR is not expressible (issue #127) |
+| `retry_exit_code` on `BashOperator`/`BashSensor` (`supports_bash_retry_exit_code()`) | 2.10 | the pre-load sentinel drops `retry_exit_code` so the sensor still constructs; the closed {0,1,2} exit-code contract is a 2.10+ feature (issue #128) |
+| Assets (replace datasets) (`supports_assets()`) | 3.0 | datasets are used instead |
+
+Notes:
+
+- **`supports_inlet_events()`** — `True` for Airflow >= 2.10.0. Also enables inlet-event dataset-readiness validation via `ShortCircuitOperator` in `start_op()`.
+- **`supports_assets()`** — `True` for Airflow >= 3.0.0, enabling asset-based scheduling (`Asset`/`AssetAny`/`AssetAll`).
+- The `scheduledDate` templating (`ts_as_datetime`/`sl_dates` macros) uses Jinja's `@pass_context` so it renders correctly during execution on every version, including Airflow 2.5–2.9 (issue #126).
+- The dataset-triggering strategy is set with the `dataset_triggering_strategy` option (`any` — default — or `all`). Below Airflow 2.9, `any` behaves as `all`; use Airflow >= 2.9 for true OR (`DatasetAny`) triggering.
+
+Advanced opt-in features (deferrable cloud pre-load, the pre-load not-ready sentinel's forced exit-code contract, dataset aliases) remain 2.10+.
 
 ### StarlakeDatasetMixin
 

--- a/starlake-airflow/pom.xml
+++ b/starlake-airflow/pom.xml
@@ -14,7 +14,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>starlake-airflow</artifactId>
-    <version>0.6.9</version>
+    <version>0.6.10</version>
     <packaging>jar</packaging>
 
 </project>

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/bash/starlake_airflow_bash_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/bash/starlake_airflow_bash_job.py
@@ -22,7 +22,7 @@ from ai.starlake.job import StarlakePreLoadStrategy, StarlakeSparkConfig, Starla
 
 from ai.starlake.airflow import StarlakeAirflowJob, StarlakeDatasetMixin
 
-from ai.starlake.airflow.compat import BaseOperator, BashOperator, BashSensor, PythonOperator
+from ai.starlake.airflow.compat import BaseOperator, BashOperator, BashSensor, PythonOperator, supports_bash_retry_exit_code
 
 class StarlakeAirflowBashJob(StarlakeAirflowJob):
     """Airflow Starlake Bash Job."""
@@ -199,6 +199,12 @@ class StarlakeAirflowBashJob(StarlakeAirflowJob):
                 # the closed {0,1,2} contract OWNS this code — a caller
                 # override would invert real-failure vs poke-again
                 kwargs['retry_exit_code'] = 2
+            # BashSensor only accepts retry_exit_code on Airflow >= 2.10; drop
+            # it (including any caller value) on older Airflow so the sensor
+            # constructs. The sentinel exit-code contract is a 2.10+/core-1.5.15
+            # opt-in feature; on 2.10+ this pop is a no-op.
+            if not supports_bash_retry_exit_code():
+                kwargs.pop('retry_exit_code', None)
             return StarlakePreloadBashSensor(
                 task_id=task_id,
                 dataset=dataset,

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/compat.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/compat.py
@@ -21,6 +21,8 @@ versions live here, so the rest of the package imports version-agnostic
 names from a single place.
 """
 
+import functools
+
 import airflow
 
 from packaging.version import Version, parse
@@ -103,8 +105,11 @@ __all__ = [
     "airflow_version",
     "supports_datasets",
     "supports_inlet_events",
+    "supports_dataset_conditions",
+    "supports_bash_retry_exit_code",
     "supports_assets",
     "api_prefix",
+    "install_dataset_extra_forwarding",
 ]
 
 
@@ -123,6 +128,20 @@ def supports_inlet_events() -> bool:
     return airflow_version() >= parse("2.10.0")
 
 
+def supports_dataset_conditions() -> bool:
+    """Conditional dataset scheduling — ``DatasetAny``/``DatasetAll`` via the
+    ``|`` and ``&`` operators — was introduced in Airflow 2.9. Before 2.9 a DAG
+    can only be scheduled on a *flat list* of datasets (native ALL semantics);
+    ANY (OR) is not expressible."""
+    return airflow_version() >= parse("2.9.0")
+
+
+def supports_bash_retry_exit_code() -> bool:
+    """``BashOperator``/``BashSensor`` gained the ``retry_exit_code`` parameter
+    in Airflow 2.10."""
+    return airflow_version() >= parse("2.10.0")
+
+
 def supports_assets() -> bool:
     """Assets replace datasets starting with Airflow 3.0."""
     return airflow_version() >= parse("3.0.0")
@@ -131,3 +150,57 @@ def supports_assets() -> bool:
 def api_prefix() -> str:
     """REST API prefix: /api/v1 on Airflow 2.x, /api/v2 on Airflow 3.x."""
     return "/api/v2" if supports_assets() else "/api/v1"
+
+
+def install_dataset_extra_forwarding() -> bool:
+    """Airflow < 2.10 producer-side compat: forward an outlet ``Dataset``'s own
+    ``extra`` onto the emitted ``DatasetEvent``.
+
+    Before Airflow 2.10 there is no ``outlet_events`` runtime accessor, and the
+    default task emission path calls ``DatasetManager.register_dataset_change``
+    **without** an ``extra`` — so every task-emitted ``DatasetEvent.extra`` is
+    ``{}``. ``StarlakeDatasetMixin.pre_execute`` stashes the rendered ``extra``
+    on the outlet ``Dataset`` itself; this thin wrapper reads it back when the
+    caller passes none, producing exactly one event carrying the runtime extra
+    with no duplicate emission and no bypass of the internal-API path.
+
+    Only installs on Airflow 2.4–2.9 (datasets present, inlet events absent);
+    a no-op on 2.10+ (native accessor) and 3.x (assets). Idempotent — safe to
+    call more than once. Returns ``True`` when the wrapper is (or already was)
+    in place, ``False`` when this Airflow version needs no wrapper.
+
+    Note: the wrapper patches ``DatasetManager.register_dataset_change``
+    process-wide, so it applies to every outlet ``Dataset`` in the process, not
+    only Starlake's. In practice it is a no-op unless a dataset carries its own
+    ``extra`` (stock Airflow < 2.10 emits ``{}``): it forwards that declared
+    ``extra`` onto the event, which is the behaviour datasets with an ``extra``
+    intend. A deployment installing a custom ``[core] dataset_manager_class``
+    that overrides ``register_dataset_change`` on a subclass is not wrapped.
+    """
+    if supports_inlet_events() or not supports_datasets():
+        return False
+
+    from airflow.datasets.manager import DatasetManager
+
+    original = DatasetManager.register_dataset_change
+    if getattr(original, "__starlake_extra_forwarding__", False):
+        return True  # already installed
+
+    @functools.wraps(original)
+    def register_dataset_change(self, *args, dataset=None, extra=None, **kwargs):
+        # Default emission path passes no extra pre-2.10; fall back to the
+        # extra the mixin stashed on the outlet Dataset itself. Test ``is None``
+        # (not falsiness) so an explicit empty ``extra={}`` from a caller is
+        # honoured rather than overwritten by the dataset's own extra.
+        if extra is None:
+            extra = getattr(dataset, "extra", None)
+        return original(self, *args, dataset=dataset, extra=extra, **kwargs)
+
+    register_dataset_change.__starlake_extra_forwarding__ = True
+    DatasetManager.register_dataset_change = register_dataset_change
+    return True
+
+
+# Install the producer-side wrapper eagerly so it is in place in the worker
+# process before any task emits an outlet event. No-op on 2.10+/3.x.
+install_dataset_extra_forwarding()

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_job.py
@@ -1477,10 +1477,24 @@ class StarlakeDatasetMixin:
         if self.scheduled_dataset:
             dataset = Dataset(uri=self.scheduled_dataset, extra=self.extra)
             self.outlets.append(dataset)
-        for outlet in self.outlets:
-            outlet_event = context["outlet_events"][outlet]
-            self.log.info(f"updating outlet event {outlet_event} with extra {self.extra}")
-            outlet_event.extra = self.extra
+        if supports_inlet_events():
+            # Airflow 2.10+: the runtime outlet_events accessor carries extra
+            # onto the emitted DatasetEvent (register_dataset_change(extra=...)).
+            for outlet in self.outlets:
+                outlet_event = context["outlet_events"][outlet]
+                self.log.info(f"updating outlet event {outlet_event} with extra {self.extra}")
+                outlet_event.extra = self.extra
+        else:
+            # Airflow < 2.10: no outlet_events accessor and the default emission
+            # path calls register_dataset_change without an extra. Re-sync the
+            # rendered extra onto each outlet Dataset itself — render_template_fields
+            # replaced self.extra with a new dict, breaking the by-reference link
+            # established in __init__. The register_dataset_change wrapper installed
+            # in compat.py then forwards this extra onto the DatasetEvent.
+            for outlet in self.outlets:
+                if isinstance(outlet, Dataset):
+                    outlet.extra = self.extra  # attrs Dataset is not frozen
+                    self.log.info(f"updating outlet {outlet} with extra {self.extra}")
         return super().pre_execute(context)
 
 class StarlakeCloudPreloadSensor(StarlakeDatasetMixin, BaseSensorOperator):

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_orchestration.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_orchestration.py
@@ -16,6 +16,10 @@
 
 from __future__ import annotations
 
+import logging
+
+from jinja2 import pass_context
+
 from ai.starlake.airflow.starlake_airflow_job import StarlakeAirflowJob, AirflowDataset
 
 from ai.starlake.common import sl_cron_start_end_dates, sl_scheduled_date, sl_scheduled_dataset, sl_timestamp_format, StarlakeParameters
@@ -28,7 +32,7 @@ from ai.starlake.orchestration import AbstractOrchestration, StarlakeSchedule, S
 
 from airflow import DAG
 
-from ai.starlake.airflow.compat import BaseOperator, Dataset, TaskGroup, get_current_context
+from ai.starlake.airflow.compat import BaseOperator, Dataset, TaskGroup, get_current_context, supports_dataset_conditions, airflow_version
 
 from ai.starlake.airflow.starlake_airflow_api import StarlakeAirflowApiClient
 
@@ -81,19 +85,49 @@ class AirflowPipeline(AbstractPipeline[DAG, BaseOperator, TaskGroup, Dataset], A
             max_active_runs = 1
             default_args.update({'max_active_runs': 1})
             from functools import reduce
-            if job.dataset_triggering_strategy == DatasetTriggeringStrategy.ANY:
-                airflow_schedule = reduce(lambda a, b: a | b, events)
+            if supports_dataset_conditions():
+                # Airflow >= 2.9: conditional dataset expressions.
+                # ANY → DatasetAny (|), ALL → DatasetAll (&).
+                if job.dataset_triggering_strategy == DatasetTriggeringStrategy.ANY:
+                    airflow_schedule = reduce(lambda a, b: a | b, events)
+                else:
+                    airflow_schedule = reduce(lambda a, b: a & b, events)
             else:
-                airflow_schedule = reduce(lambda a, b: a & b, events)
+                # Airflow < 2.9: DatasetAny/DatasetAll (| and &) do not exist.
+                # A flat list schedule triggers when ALL datasets are updated
+                # (native 2.4+ semantics). ANY (OR) cannot be expressed, so it
+                # degrades to ALL (flat list) with a warning rather than failing
+                # DAG construction (issue #125).
+                if job.dataset_triggering_strategy == DatasetTriggeringStrategy.ANY:
+                    logging.getLogger(__name__).warning(
+                        "ANY dataset-triggering strategy requires Airflow >= 2.9 "
+                        "(conditional dataset scheduling); falling back to ALL "
+                        "(flat-list) semantics on Airflow %s.",
+                        airflow_version(),
+                    )
+                airflow_schedule = list(events)
             if self.job.data_cycle_enabled and not self.job.data_cycle:
                 self.job.data_cycle = self.computed_cron_expr
                     
 
-        def ts_as_datetime(ts, context: Context = None):
+        # These macros run inside Jinja at template-render time. ``@pass_context``
+        # makes Jinja hand its render context (which carries ``task_instance``)
+        # to the macro, so we do NOT depend on ``get_current_context()`` — that
+        # contextvar is only established during rendering from Airflow 2.10 on,
+        # so relying on it broke dataset-triggered DAG execution on 2.5-2.9
+        # (issue #125). Template call sites are UNCHANGED: Jinja injects the
+        # context automatically, so ``ts_as_datetime(data_interval_end | ts)``
+        # still passes a single visible argument. The get_current_context()
+        # branch is a defensive fallback for a Jinja render whose context has no
+        # ``task_instance`` (Airflow always supplies it during task rendering);
+        # these macros are only ever invoked from templates, never called
+        # directly from Python.
+        @pass_context
+        def ts_as_datetime(context, ts):
             from datetime import datetime
-            if not context:
-                context = get_current_context()
-            ti = context["task_instance"]
+            ti = (context.get("task_instance") if hasattr(context, "get") else None)
+            if ti is None:
+                ti = get_current_context()["task_instance"]
             sl_logical_date = ti.xcom_pull(task_ids="start", key=StarlakeParameters.DATA_INTERVAL_END_PARAMETER.value)
             if sl_logical_date:
                 ts = sl_logical_date
@@ -105,10 +139,11 @@ class AirflowPipeline(AbstractPipeline[DAG, BaseOperator, TaskGroup, Dataset], A
                 return ts
 
         from datetime import datetime
-        def sl_dates(cron_expr: str, start_time: datetime, context: Context = None) -> str:
-            if not context:
-                context = get_current_context()
-            ti = context["task_instance"]
+        @pass_context
+        def sl_dates(context, cron_expr: str, start_time: datetime) -> str:
+            ti = (context.get("task_instance") if hasattr(context, "get") else None)
+            if ti is None:
+                ti = get_current_context()["task_instance"]
             sl_data_interval_start = ti.xcom_pull(task_ids="start", key=StarlakeParameters.DATA_INTERVAL_START_PARAMETER.value)
             sl_data_interval_end = ti.xcom_pull(task_ids="start", key=StarlakeParameters.DATA_INTERVAL_END_PARAMETER.value)
             if sl_data_interval_start and sl_data_interval_end:

--- a/starlake-airflow/src/main/python/setup.py
+++ b/starlake-airflow/src/main/python/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 import os
 
-version = os.environ.get("PROJECT_VERSION", "0.6.9")
+version = os.environ.get("PROJECT_VERSION", "0.6.10")
 
 setup(name='starlake-airflow',
       version=version,
@@ -23,7 +23,12 @@ setup(name='starlake-airflow',
       packages=find_packages(include=['ai', 'ai.*']),
       install_requires=['starlake-orchestration~=0.5'],
       extras_require={
-        "airflow": ["airflow>=2.10.0"],
+        # Floor of the full data-aware round-trip: datasets landed in 2.4,
+        # triggering_dataset_events (consumer side) in 2.5. The producer side
+        # is version-portable via install_dataset_extra_forwarding (issue #125);
+        # advanced opt-in features (deferrable cloud pre-load, dataset aliases)
+        # still require 2.10+ and are out of scope of this floor.
+        "airflow": ["airflow>=2.5.0"],
         "shell": [],
         "gcp": [], #["apache-airflow-providers-google>=10.0.7"]
         "aws": [],

--- a/tests/airflow/dataset_compat.py
+++ b/tests/airflow/dataset_compat.py
@@ -30,16 +30,31 @@ try:
     AIRFLOW_AVAILABLE = True
     AIRFLOW_VERSION = tuple(int(x) for x in airflow.__version__.split(".")[:2])
     SUPPORTS_ASSETS = AIRFLOW_VERSION >= (3, 0)
+    # Conditional dataset expressions (DatasetAny/DatasetAll via |/&) landed in
+    # Airflow 2.9. Before that, datasets still exist but a DAG can only be
+    # scheduled on a flat list (native ALL semantics) — so DatasetAll/DatasetAny
+    # are absent. Do NOT conflate that with "Airflow unavailable" (issue #125).
+    SUPPORTS_DATASET_CONDITIONS = SUPPORTS_ASSETS or AIRFLOW_VERSION >= (2, 9)
+    # The condition object can be *built* on 2.9, but the timetable only exposes
+    # it (``.dataset_condition`` / ``.asset_condition``) from Airflow 2.10 on —
+    # so condition *introspection* in tests needs a separate, higher boundary.
+    SUPPORTS_CONDITION_INTROSPECTION = SUPPORTS_ASSETS or AIRFLOW_VERSION >= (2, 10)
     if SUPPORTS_ASSETS:
         from airflow.sdk import Asset as Dataset
         from airflow.sdk import AssetAll as DatasetAll
         from airflow.sdk import AssetAny as DatasetAny
     else:
-        from airflow.datasets import Dataset, DatasetAll, DatasetAny
+        from airflow.datasets import Dataset
+        if SUPPORTS_DATASET_CONDITIONS:
+            from airflow.datasets import DatasetAll, DatasetAny
+        else:
+            DatasetAll = DatasetAny = None
 except ImportError:  # pragma: no cover — collection guard only
     AIRFLOW_AVAILABLE = False
     AIRFLOW_VERSION = (0, 0)
     SUPPORTS_ASSETS = False
+    SUPPORTS_DATASET_CONDITIONS = False
+    SUPPORTS_CONDITION_INTROSPECTION = False
     Dataset = DatasetAll = DatasetAny = None
 
 # Name of the condition attribute on dataset/asset-triggered timetables.

--- a/tests/airflow/test_airflow_dataset_extra_compat.py
+++ b/tests/airflow/test_airflow_dataset_extra_compat.py
@@ -1,0 +1,258 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Issue #125 — Airflow < 2.10 dataset outlet ``extra`` propagation.
+
+Before Airflow 2.10 there is no ``context["outlet_events"]`` accessor to carry
+Starlake's runtime metadata onto an emitted ``DatasetEvent``. The producer-side
+compat fix has two halves:
+
+* ``StarlakeDatasetMixin.pre_execute`` pushes the rendered ``extra`` onto each
+  outlet ``Dataset`` itself when ``supports_inlet_events()`` is ``False``.
+* ``compat.install_dataset_extra_forwarding`` wraps
+  ``DatasetManager.register_dataset_change`` so the default emission path
+  forwards that outlet's own ``extra`` when the caller passes none.
+
+The dev/CI environment runs Airflow >= 2.10, so the pre-2.10 path is *simulated*
+by forcing ``supports_inlet_events()`` to ``False``; the branch logic itself is
+version-independent Python.
+"""
+
+from __future__ import annotations
+
+import datetime
+import types
+
+import pytest
+
+from ai.starlake.airflow import compat
+from ai.starlake.airflow.compat import Dataset, install_dataset_extra_forwarding
+from ai.starlake.common import StarlakeParameters
+import ai.starlake.airflow.starlake_airflow_job as jobmod
+from ai.starlake.airflow.starlake_airflow_job import StarlakeEmptyOperator
+from ai.starlake.dataset import StarlakeDataset
+
+URI = StarlakeParameters.URI_PARAMETER.value
+SINK = StarlakeParameters.SINK_PARAMETER.value
+SCHEDULED_DATE = StarlakeParameters.SCHEDULED_DATE_PARAMETER.value
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def stub_super_pre_execute(monkeypatch):
+    """Stub ``BaseOperator.pre_execute`` — the lineage-decorated Airflow tail.
+
+    Isolates the mixin's own branch logic (the only thing issue #125 changed)
+    from Airflow's ``@prepare_lineage`` machinery, which would otherwise need a
+    live DAG run, XCom and a DB session.
+    """
+    from airflow.models.baseoperator import BaseOperator
+
+    monkeypatch.setattr(BaseOperator, "pre_execute", lambda self, context: None)
+
+
+def _build_operator(dataset):
+    from airflow import DAG
+
+    with DAG(dag_id="issue125", start_date=datetime.datetime(2024, 1, 1), schedule=None):
+        return StarlakeEmptyOperator(task_id="t", dataset=dataset, source="src")
+
+
+def _context():
+    import pytz
+
+    ti = types.SimpleNamespace(
+        start_date=datetime.datetime(2024, 1, 1, tzinfo=pytz.UTC)
+    )
+    return {"ti": ti}
+
+
+# ---------------------------------------------------------------------------
+# Mixin — pre-2.10 fallback branch (Airflow 2.x concern; assets always carry
+# the accessor so the fallback is meaningless on Airflow 3).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    compat.supports_assets(),
+    reason="pre-2.10 outlet-extra fallback is an Airflow 2.x concern",
+)
+class TestMixinPre210Fallback:
+
+    def test_rendered_extra_pushed_onto_every_outlet(
+        self, monkeypatch, stub_super_pre_execute
+    ):
+        monkeypatch.setattr(jobmod, "supports_inlet_events", lambda: False)
+        op = _build_operator(StarlakeDataset(name="starbake.orders", cron="0 * * * *"))
+        # render_template_fields replaces self.extra with a NEW dict at runtime,
+        # breaking the by-reference link established in __init__; simulate that
+        # so we prove pre_execute re-syncs the outlets to the rendered dict.
+        op.extra = dict(op.extra)
+        assert op.outlets and op.outlets[0].extra is not op.extra  # link broken
+
+        op.pre_execute(_context())
+
+        assert op.outlets
+        for outlet in op.outlets:
+            assert isinstance(outlet, Dataset)
+            assert outlet.extra is op.extra                 # re-synced
+            assert outlet.extra["ts"]                       # runtime ts attached
+            assert outlet.extra[URI] == "starbake_orders"
+            assert outlet.extra[SINK] == "starbake.orders"
+            assert outlet.extra[SCHEDULED_DATE]             # scheduled-date carried
+
+    def test_outlet_events_accessor_not_touched(
+        self, monkeypatch, stub_super_pre_execute
+    ):
+        monkeypatch.setattr(jobmod, "supports_inlet_events", lambda: False)
+        op = _build_operator("starbake.orders")  # plain string dataset, no cron
+
+        class _Boom(dict):
+            def __getitem__(self, key):  # pragma: no cover - must never run
+                raise AssertionError(
+                    "outlet_events accessor must not be used on the pre-2.10 path"
+                )
+
+        ctx = _context()
+        ctx["outlet_events"] = _Boom()
+
+        op.pre_execute(ctx)  # must not raise
+
+        assert op.outlets[0].extra["ts"]
+        assert op.outlets[0].extra["source"] == "src"
+
+
+# ---------------------------------------------------------------------------
+# Mixin — native 2.10+ path stays unchanged (regression guard).
+# ---------------------------------------------------------------------------
+
+class TestMixin210Accessor:
+
+    def test_extra_set_via_outlet_events_accessor(
+        self, monkeypatch, stub_super_pre_execute
+    ):
+        monkeypatch.setattr(jobmod, "supports_inlet_events", lambda: True)
+        op = _build_operator(StarlakeDataset(name="starbake.orders", cron="0 * * * *"))
+        op.extra = dict(op.extra)
+        init_outlet = op.outlets[0]
+
+        events = {}
+
+        class _Accessor:
+            def __getitem__(self, outlet):
+                return events.setdefault(
+                    id(outlet), types.SimpleNamespace(extra=None)
+                )
+
+        ctx = _context()
+        ctx["outlet_events"] = _Accessor()
+
+        op.pre_execute(ctx)
+
+        assert events, "the 2.10+ path must go through the outlet_events accessor"
+        for event in events.values():
+            assert event.extra is op.extra
+        # native path must NOT mutate the __init__-time outlet's own extra
+        assert init_outlet.extra is not op.extra
+
+
+# ---------------------------------------------------------------------------
+# compat.install_dataset_extra_forwarding — register_dataset_change wrapper.
+# DatasetManager only exists on Airflow 2.4-2.x (assets.manager on 3.x).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    not compat.supports_datasets(),
+    reason="DatasetManager only exists on Airflow 2.4-2.x",
+)
+class TestRegisterDatasetChangeForwarding:
+
+    @pytest.fixture
+    def spy_manager(self, monkeypatch):
+        """Force the pre-2.10 install path and swap in a recording stub as the
+        ``register_dataset_change`` the wrapper will delegate to."""
+        from airflow.datasets.manager import DatasetManager
+
+        monkeypatch.setattr(compat, "supports_inlet_events", lambda: False)
+        monkeypatch.setattr(compat, "supports_datasets", lambda: True)
+
+        recorded = {"calls": 0}
+
+        def spy(self, *, task_instance=None, dataset=None, extra=None, session=None, **kwargs):
+            recorded["calls"] += 1
+            recorded["extra"] = extra
+            recorded["dataset"] = dataset
+            return "event"
+
+        monkeypatch.setattr(DatasetManager, "register_dataset_change", spy)
+        return DatasetManager, recorded
+
+    def test_forwards_outlet_extra_when_none_passed(self, spy_manager):
+        DatasetManager, recorded = spy_manager
+        assert install_dataset_extra_forwarding() is True
+
+        mgr = object.__new__(DatasetManager)
+        DatasetManager.register_dataset_change(
+            mgr, task_instance=None, dataset=Dataset(uri="d", extra={URI: "d"}), session=None
+        )
+
+        assert recorded["extra"] == {URI: "d"}
+        assert recorded["calls"] == 1
+
+    def test_explicit_extra_is_preserved(self, spy_manager):
+        DatasetManager, recorded = spy_manager
+        install_dataset_extra_forwarding()
+
+        mgr = object.__new__(DatasetManager)
+        DatasetManager.register_dataset_change(
+            mgr,
+            task_instance=None,
+            dataset=Dataset(uri="d", extra={URI: "d"}),
+            extra={"a": 1},
+            session=None,
+        )
+
+        assert recorded["extra"] == {"a": 1}
+
+    def test_explicit_empty_extra_is_preserved(self, spy_manager):
+        DatasetManager, recorded = spy_manager
+        install_dataset_extra_forwarding()
+
+        mgr = object.__new__(DatasetManager)
+        # An explicit empty dict is a deliberate "no extra" — it must NOT be
+        # overwritten by the dataset's own extra (the wrapper tests ``is None``).
+        DatasetManager.register_dataset_change(
+            mgr,
+            task_instance=None,
+            dataset=Dataset(uri="d", extra={URI: "d"}),
+            extra={},
+            session=None,
+        )
+
+        assert recorded["extra"] == {}
+
+    def test_install_is_idempotent(self, spy_manager):
+        DatasetManager, _ = spy_manager
+        install_dataset_extra_forwarding()
+        wrapped = DatasetManager.register_dataset_change
+        assert install_dataset_extra_forwarding() is True
+        assert DatasetManager.register_dataset_change is wrapped  # not re-wrapped
+
+    def test_noop_when_inlet_events_supported(self, monkeypatch):
+        monkeypatch.setattr(compat, "supports_inlet_events", lambda: True)
+        assert install_dataset_extra_forwarding() is False

--- a/tests/airflow/test_airflow_options.py
+++ b/tests/airflow/test_airflow_options.py
@@ -323,7 +323,11 @@ class TestAirflowPipeline:
 
     def test_dag_with_dataset_triggers_any(self):
         """Pipeline with ANY strategy produces a dataset/asset-triggered DAG
-        carrying all upstream datasets as events."""
+        carrying all upstream datasets as events.
+
+        On Airflow >= 2.9 this uses a ``DatasetAny`` (``|``) condition; below 2.9
+        (no conditional operators) it degrades to a native flat-list dataset
+        schedule — still a dataset-triggered timetable (issue #125)."""
         from ai.starlake.dataset import DatasetTriggeringStrategy
 
         pipeline = self._make_dataset_pipeline("any")
@@ -353,3 +357,18 @@ class TestAirflowPipeline:
         assert "Dataset" in timetable_cls or "Asset" in timetable_cls
         assert len(pipeline.events) == 2
         assert pipeline.job.dataset_triggering_strategy == DatasetTriggeringStrategy.ALL
+
+    def test_any_below_2_9_falls_back_to_all_with_warning(self, caplog):
+        """Below Airflow 2.9 (no DatasetAny/``|``) the ANY strategy degrades to
+        a native flat-list dataset schedule and logs a warning; on 2.9+ it uses
+        the conditional operator natively and does not warn (issue #125)."""
+        import logging
+
+        from ai.starlake.airflow.compat import supports_dataset_conditions
+
+        with caplog.at_level(logging.WARNING):
+            pipeline = self._make_dataset_pipeline("any")
+        timetable_cls = type(pipeline.dag.timetable).__name__
+        assert "Dataset" in timetable_cls or "Asset" in timetable_cls
+        warned = any("falling back to ALL" in r.getMessage() for r in caplog.records)
+        assert warned is (not supports_dataset_conditions())

--- a/tests/airflow/test_airflow_runtime.py
+++ b/tests/airflow/test_airflow_runtime.py
@@ -56,6 +56,7 @@ from tests.airflow.dataset_compat import (
     AIRFLOW_AVAILABLE,
     AIRFLOW_VERSION,
     SUPPORTS_ASSETS,
+    SUPPORTS_CONDITION_INTROSPECTION,
     Dataset,
     DatasetAll,
     DatasetAny,
@@ -151,17 +152,42 @@ def _register_dags(pipelines):
 
 
 def _dag_test(dag):
-    """Run ``dag.test()`` with version-appropriate kwargs.
+    """Run ``dag.test()`` with version-appropriate kwargs and return the DagRun.
 
     Airflow 3 renamed ``execution_date`` to ``logical_date`` and serializes
     ``run_conf`` as strict JSON — pass the start date as an ISO string there
     (the same shape a REST-triggered run's conf has in production).
+
+    Airflow < 2.10's ``dag.test()`` executes the DAG but returns ``None`` (the
+    DagRun return value was added later). Fetch the persisted DagRun from the
+    metadata DB in that case so callers can still assert on its final state.
     """
     if SUPPORTS_ASSETS:
         run_conf = {"start_date": EXECUTION_DATE.isoformat(), "backfill": False}
-        return dag.test(logical_date=EXECUTION_DATE, run_conf=run_conf)
-    run_conf = {"start_date": EXECUTION_DATE, "backfill": False}
-    return dag.test(execution_date=EXECUTION_DATE, run_conf=run_conf)
+        dr = dag.test(logical_date=EXECUTION_DATE, run_conf=run_conf)
+    else:
+        run_conf = {"start_date": EXECUTION_DATE, "backfill": False}
+        dr = dag.test(execution_date=EXECUTION_DATE, run_conf=run_conf)
+    if dr is None:
+        from airflow.models import DagRun
+        from airflow.utils.session import create_session
+
+        # Fetch the exact run dag.test() just executed (filter by the same
+        # execution_date), not merely the latest run for this dag_id — a
+        # dataset-triggered DAG can persist downstream runs at later dates.
+        with create_session() as session:
+            dr = (
+                session.query(DagRun)
+                .filter(
+                    DagRun.dag_id == dag.dag_id,
+                    DagRun.execution_date == EXECUTION_DATE,
+                )
+                .one_or_none()
+            )
+        assert dr is not None, (
+            f"dag.test() persisted no DagRun for {dag.dag_id} @ {EXECUTION_DATE}"
+        )
+    return dr
 
 
 # ===================================================================
@@ -316,6 +342,53 @@ class TestAirflowRuntimeLoad:
                 f"in {all_outlet_uris}"
             )
 
+    def test_load_events_carry_runtime_extra(self, executed_load_dags):
+        """The persisted Dataset/Asset events carry Starlake's runtime extra —
+        the real end-to-end producer round-trip against Airflow's own emission
+        path (issue #125).
+
+        On Airflow < 2.10 this exercises the ``register_dataset_change`` wrapper
+        (the extra would otherwise be dropped); on 2.10+ the ``outlet_events``
+        accessor; on 3.x the asset event path. This is the assertion the mocked
+        unit test cannot make — it validates the *real* method signature and
+        that the extra actually reaches the emitted event.
+        """
+        _, _, _ = executed_load_dags
+        from airflow.utils.session import create_session
+        from ai.starlake.common import StarlakeParameters
+
+        URI = StarlakeParameters.URI_PARAMETER.value
+        SINK = StarlakeParameters.SINK_PARAMETER.value
+        if SUPPORTS_ASSETS:
+            from airflow.models.asset import AssetEvent as EventModel, AssetModel as UriModel
+            id_col = "asset_id"
+        else:
+            from airflow.models.dataset import DatasetEvent as EventModel, DatasetModel as UriModel
+            id_col = "dataset_id"
+
+        with create_session() as session:
+            uri_by_id = {row.id: row.uri for row in session.query(UriModel).all()}
+            table_extras = {}
+            for event in session.query(EventModel).all():
+                uri = uri_by_id.get(getattr(event, id_col))
+                # The per-table load outlets have uri "starbake_<table>"; the
+                # DAG-level completion dataset ("airflow_starbake_tables_*") is a
+                # different concern and is excluded by the startswith filter.
+                if uri and uri.startswith("starbake_"):
+                    table_extras[uri] = event.extra or {}
+
+        assert table_extras, "the load run emitted no per-table dataset/asset events"
+        # issue #125 regression guard: each table event must carry the full
+        # runtime metadata onto the event, not be dropped to {}.
+        for uri, extra in table_extras.items():
+            assert extra.get(URI), f"event for {uri} lost {URI} (extra={extra})"
+            assert extra.get(SINK), f"event for {uri} lost {SINK} (extra={extra})"
+            assert "ts" in extra, f"event for {uri} lost ts (extra={extra})"
+        for table in ("customers", "orders", "products"):
+            assert any(table in uri for uri in table_extras), (
+                f"no per-table event for '{table}'; saw {set(table_extras)}"
+            )
+
 
 # ===================================================================
 # TestAirflowRuntimeTransform
@@ -388,10 +461,22 @@ class TestAirflowDatasetTriggering:
             )
 
     def test_any_strategy_uses_or_combination(self, transform_pipelines_loaded):
-        """Default strategy (ANY) builds the condition with DatasetAny/AssetAny."""
+        """Default strategy (ANY) builds the condition with DatasetAny/AssetAny.
+
+        The timetable only exposes the condition object from Airflow 2.10 on;
+        below that (incl. 2.9, where DatasetAny builds but isn't introspectable,
+        and 2.5-2.8, where ANY degrades to a flat list) we can only assert the
+        DAG is dataset-triggered (issue #125)."""
         pls, _, _ = transform_pipelines_loaded
         for pipeline in pls:
             timetable = pipeline.dag.timetable
+            if not SUPPORTS_CONDITION_INTROSPECTION:
+                assert "Dataset" in type(timetable).__name__, (
+                    f"Expected a dataset-triggered timetable, got "
+                    f"{type(timetable).__name__}"
+                )
+                assert len(pipeline.events) > 0
+                continue
             assert hasattr(timetable, _CONDITION_ATTR), (
                 f"Timetable {type(timetable).__name__} has no {_CONDITION_ATTR}"
             )
@@ -447,6 +532,14 @@ class TestAirflowDatasetTriggering:
             pass
 
         timetable = pipeline.dag.timetable
+        if not SUPPORTS_CONDITION_INTROSPECTION:
+            # Below Airflow 2.10 the timetable does not expose the condition
+            # object (2.9 builds DatasetAll but hides it; 2.5-2.8 use a native
+            # flat list). Either way the DAG is dataset-triggered.
+            assert "Dataset" in type(timetable).__name__
+            assert len(pipeline.events) == 2
+            return
+
         assert hasattr(timetable, _CONDITION_ATTR)
         condition = getattr(timetable, _CONDITION_ATTR)
 

--- a/tests/airflow/test_airflow_sl_pre_load_sentinel.py
+++ b/tests/airflow/test_airflow_sl_pre_load_sentinel.py
@@ -307,6 +307,7 @@ class TestBashSensorMode:
 
     def test_sensor_construction(self, tmp_path):
         from ai.starlake.airflow.bash.starlake_airflow_bash_job import StarlakePreloadBashSensor
+        from ai.starlake.airflow.compat import supports_bash_retry_exit_code
         sensor = self._sensor(tmp_path)
         assert isinstance(sensor, StarlakePreloadBashSensor)
         # 6.2 contracts intact
@@ -314,8 +315,11 @@ class TestBashSensorMode:
         assert sensor.timeout == 120
         assert sensor.mode == "reschedule"
         assert sensor.retries == 0
-        # 6.12 — closed exit-code contract
-        assert sensor.retry_exit_code == 2
+        # 6.12 — closed exit-code contract. retry_exit_code is an Airflow 2.10+
+        # BashSensor parameter; below 2.10 it is dropped so the sensor still
+        # constructs (issue #125).
+        expected_rec = 2 if supports_bash_retry_exit_code() else None
+        assert getattr(sensor, "retry_exit_code", None) == expected_rec
         assert sensor.env["SL_SENTINEL_SCOPE"] == "{{ ti.dag_id }}__{{ run_id }}"
         cmd = sensor.bash_command
         assert f'cd "{str(tmp_path)}" &&' in cmd
@@ -325,9 +329,13 @@ class TestBashSensorMode:
     def test_caller_retry_exit_code_override_is_ignored(self, tmp_path):
         """Review finding — the closed {0,1,2} contract owns retry_exit_code:
         a caller override would invert real-failure vs poke-again."""
+        from ai.starlake.airflow.compat import supports_bash_retry_exit_code
         job = _make_bash_job(_bash_sentinel_options(tmp_path, self.SENSOR_EXTRA))
         sensor = job.sl_pre_load(domain="starbake", tables={"customers"}, retry_exit_code=1)
-        assert sensor.retry_exit_code == 2
+        # Below 2.10 there is no retry_exit_code param at all, so the caller
+        # value is dropped (not honoured either) — "ignored" holds on both.
+        expected_rec = 2 if supports_bash_retry_exit_code() else None
+        assert getattr(sensor, "retry_exit_code", None) == expected_rec
 
     def test_sensor_without_sentinel_unchanged(self, tmp_path):
         """6.2 regression pin — sensor mode without the sentinel option keeps
@@ -338,7 +346,9 @@ class TestBashSensorMode:
         }
         options.update(self.SENSOR_EXTRA)
         sensor = _make_bash_job(options).sl_pre_load(domain="starbake", tables={"customers"})
-        assert sensor.retry_exit_code is None
+        # No sentinel → no forced exit-code contract. On 2.10+ the attribute is
+        # present and None; below 2.10 the BashSensor has no such attribute.
+        assert getattr(sensor, "retry_exit_code", None) is None
         assert "return_code=$?" not in sensor.bash_command
 
     def test_sensor_wrapper_exit_codes(self, tmp_path):

--- a/tests/airflow/test_airflow_triggering_strategy.py
+++ b/tests/airflow/test_airflow_triggering_strategy.py
@@ -31,6 +31,7 @@ from tests.airflow.dataset_compat import (
     AIRFLOW_AVAILABLE,
     CONDITION_ATTR,
     SUPPORTS_ASSETS,
+    SUPPORTS_CONDITION_INTROSPECTION,
     Dataset,
     DatasetAll,
     DatasetAny,
@@ -44,8 +45,14 @@ from tests.shared.triggering_scenarios import (
     make_dependencies,
 )
 
+# This module *introspects* the native condition object off the timetable
+# (``.dataset_condition``/``.asset_condition``). The DatasetAny/DatasetAll
+# operators exist from 2.9, but the timetable only exposes the condition from
+# Airflow 2.10 on. Below 2.10 the ANY/ALL build/fallback behaviour is covered
+# by the runtime/options tests instead (issue #125).
 pytestmark = pytest.mark.skipif(
-    not AIRFLOW_AVAILABLE, reason="Requires Apache Airflow"
+    not SUPPORTS_CONDITION_INTROSPECTION,
+    reason="timetable condition introspection (dataset_condition) needs Airflow >= 2.10",
 )
 
 

--- a/tests/shared/conftest.py
+++ b/tests/shared/conftest.py
@@ -41,7 +41,7 @@ _DOT_ENV = dotenv_values(_DOT_ENV_PATH) if _DOT_ENV_PATH.is_file() else dotenv_v
 
 # Defaults used when neither .env nor system env defines a variable.
 _DEFAULTS = {
-    "SL_VERSION": "1.5.11",
+    "SL_VERSION": "1.5.16",
     "SL_ENV": "DUCKDB",
     "SL_VERSION_SECONDARY": "1.5.15",
 }


### PR DESCRIPTION
## Summary

Lowers the `starlake-airflow` floor from **2.10.0** to **2.5.0** and makes the whole module + test suite pass on **Airflow 2.5.3, 2.9.3, 2.10.5 and 3.3.0**, so the full data-aware round-trip (a load DAG emits dataset outlets carrying Starlake's runtime metadata; a transform DAG is triggered by them and reads that metadata) works across the range.

Closes **#125** (producer-side outlet `extra` below 2.10) and three distinct defects surfaced by lowering the floor: **#126**, **#127**, **#128**.

## Changes

**Producer outlet `extra` (#125)** — pre-2.10 there is no `outlet_events` accessor:
- `StarlakeDatasetMixin.pre_execute` re-syncs the rendered `extra` onto each outlet `Dataset` on the pre-2.10 branch (2.10+ accessor path unchanged).
- `compat.install_dataset_extra_forwarding()` wraps `DatasetManager.register_dataset_change` to forward the outlet's `extra` when the caller passes none (idempotent, process-wide, no-op on 2.10+/3.x; uses `extra is None` so an explicit `{}` is honoured).

**Version-gated compat found while lowering the floor:**
- **#126** — `ts_as_datetime`/`sl_dates` macros use Jinja `@pass_context` instead of `get_current_context()` (only established at render time from 2.10), so `scheduledDate` rendering — and thus dataset-triggered DAG *execution* — works on 2.5–2.9. Template call sites unchanged.
- **#127** — conditional dataset scheduling (`DatasetAny`/`DatasetAll`, 2.9+) gated on `supports_dataset_conditions()`; below 2.9 `ALL` uses a native flat-list schedule and `ANY` degrades to `ALL` with a logged warning instead of a `TypeError`.
- **#128** — the pre-load sentinel drops `retry_exit_code` (2.10+) below 2.10 so the `BashSensor` constructs; 2.10+ behaviour byte-identical.

**Tests / infra:**
- New `test_airflow_dataset_extra_compat.py` (both producer branches + the wrapper, incl. explicit-empty-extra).
- `dataset_compat.py` distinguishes three boundaries: datasets, `SUPPORTS_DATASET_CONDITIONS` (>=2.9 construction) and `SUPPORTS_CONDITION_INTROSPECTION` (>=2.10 timetable `.dataset_condition`).
- Runtime/options/sentinel/triggering tests made version-aware; `_dag_test` fetches the persisted `DagRun` (filtered by `execution_date`) when `dag.test()` returns `None` below 2.10.
- New `test_load_events_carry_runtime_extra` asserts the **real** `DatasetEvent`/`AssetEvent` carries the extra end-to-end on every version (not a stub).

**CI:** added `airflow-2.5.3` (Python 3.10) and `airflow-2.9.3` legs via a per-leg `python_version` matrix override threaded to the venv and constraints URL.

**Docs / version:** README floor → 2.5.0 with an Airflow version-compatibility matrix; module version bumped `0.6.9` → `0.6.10` (setup.py + pom.xml).

## Validation (local, real Starlake CLI)

| Airflow | Python | Result |
| --- | --- | --- |
| 2.5.3 | 3.10 | 321 passed, 0 failed |
| 2.9.3 | 3.11 | 321 passed, 0 failed |
| 2.10.5 | 3.9 | 466 passed, 0 failed |
| 3.3.0 | 3.11 | 319 passed, 0 failed |

Full load→transform execution round-trip verified on all four; the new real-path event test passes on all four.

## Review

Adversarial code review (Blind Hunter / Edge Case Hunter / Acceptance Auditor) run; all 5 acceptance criteria met; actionable findings applied (`is None` guard, `_dag_test` `execution_date` filter, docstring/comment accuracy, real-path event test). By-design items (process-wide wrapper matching the issue proposal, ANY→ALL degradation, sentinel drop) documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
