### PR TITLE
fix(orchestration): normalize the data_cycle option through its setter

### DIFF
--- a/starlake-orchestration/pom.xml
+++ b/starlake-orchestration/pom.xml
@@ -11,7 +11,7 @@
     <name>Starlake Orchestration</name>
     <description>Starlake Orchestration templates and python library</description>
     <url>https://starlake.ai</url>
-    <version>0.5.4</version>
+    <version>0.5.5</version>
 
     <organization>
         <name>Starlake AI</name>

--- a/starlake-orchestration/src/main/python/ai/starlake/job/starlake_job.py
+++ b/starlake-orchestration/src/main/python/ai/starlake/job/starlake_job.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 
-from ai.starlake.common import MissingEnvironmentVariable, StarlakeCronPeriod, sl_schedule_format
+from ai.starlake.common import MissingEnvironmentVariable, StarlakeCronPeriod, is_valid_cron, sl_schedule_format
 
 from ai.starlake.job.starlake_pre_load_strategy import StarlakePreLoadStrategy
 from ai.starlake.job.starlake_options import StarlakeOptions
@@ -206,7 +206,15 @@ class IStarlakeJob(Generic[T, E], StarlakeOptions, AbstractEvent[E]):
 
         self.__optional_dataset_enabled = str(__class__.get_context_var(var_name='optional_dataset_enabled', default_value="false", options=self.options)).strip().lower() == "true"
         self.__data_cycle_enabled = str(__class__.get_context_var(var_name='data_cycle_enabled', default_value="false", options=self.options)).strip().lower() == "true"
-        self.__data_cycle = str(__class__.get_context_var(var_name='data_cycle', default_value="none", options=self.options))
+        # Route the option through the `data_cycle` SETTER: assigning the raw
+        # value to the private field left the literal "none" default in place,
+        # and `check_datasets` (`if self.data_cycle:` — "none" is truthy) then
+        # crashed the start task of every dataset-triggered DAG with
+        # "ValueError: Invalid cron expression: none" (issue #135). The setter
+        # normalizes ("none" -> None, presets -> crons, invalid -> loud
+        # ValueError at parse time) and forces None when the feature is off.
+        self.__data_cycle = None
+        self.data_cycle = str(__class__.get_context_var(var_name='data_cycle', default_value="none", options=self.options))
         self.__beyond_data_cycle_enabled = str(__class__.get_context_var(var_name='beyond_data_cycle_enabled', default_value="true", options=self.options)).strip().lower() == "true"
         self.__min_timedelta_between_runs = int(__class__.get_context_var(var_name='min_timedelta_between_runs', default_value=15*60, options=self.options))
         self.__run_dependencies_first = __class__.get_context_var(var_name='run_dependencies_first', default_value='False', options=self.options).lower() == 'true'
@@ -236,8 +244,13 @@ class IStarlakeJob(Generic[T, E], StarlakeOptions, AbstractEvent[E]):
         return self.__data_cycle_enabled
 
     @property
-    def data_cycle(self) -> str:
-        """Get the data cycle of the job"""
+    def data_cycle(self) -> Optional[str]:
+        """Get the data cycle of the job (None unless the feature is enabled).
+        The gate mirrors the setter's: the invariant "no data cycle when
+        data_cycle_enabled is false" holds at the read point regardless of how
+        the private field was populated (issue #135)."""
+        if not self.data_cycle_enabled:
+            return None
         return self.__data_cycle
 
     @data_cycle.setter

--- a/starlake-orchestration/src/main/python/setup.py
+++ b/starlake-orchestration/src/main/python/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 import os
 
-version = os.environ.get("PROJECT_VERSION", "0.5.4")
+version = os.environ.get("PROJECT_VERSION", "0.5.5")
 
 setup(name='starlake-orchestration',
       version=version,

--- a/tests/orchestration/test_data_cycle.py
+++ b/tests/orchestration/test_data_cycle.py
@@ -1,0 +1,77 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""``data_cycle`` option normalization (issue #135).
+
+The constructor used to assign the raw option value straight to the private
+field, bypassing the ``data_cycle`` setter — with the ``"none"`` default the
+literal string survived, and ``check_datasets`` (``if self.data_cycle:`` —
+``"none"`` is truthy) crashed the start task of every dataset-triggered DAG
+with ``ValueError: Invalid cron expression: none``. The constructor now routes
+through the setter, and the getter enforces the same ``data_cycle_enabled``
+gate as the setter.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.orchestration.conftest import StubJob, _STUB_MODULE_NAME
+
+
+def _job(options):
+    return StubJob(filename="test.py", module_name=_STUB_MODULE_NAME, options=options)
+
+
+class TestDataCycleNormalization:
+    def test_default_is_none_not_the_string(self):
+        """The regression: with no data_cycle option at all, the property must
+        be None — not the literal "none" default that get_cron_frequency
+        rejects at the first dataset-triggered run."""
+        job = _job({})
+        assert job.data_cycle is None
+
+    def test_disabled_ignores_any_value(self):
+        job = _job({"data_cycle": "daily"})   # data_cycle_enabled defaults to false
+        assert job.data_cycle is None
+
+    def test_enabled_none_string_is_none(self):
+        job = _job({"data_cycle_enabled": "true", "data_cycle": "none"})
+        assert job.data_cycle is None
+
+    @pytest.mark.parametrize(
+        ("preset", "cron"),
+        [
+            ("hourly", "0 * * * *"),
+            ("daily", "0 0 * * *"),
+            ("weekly", "0 0 * * 0"),
+            ("monthly", "0 0 1 * *"),
+            ("yearly", "0 0 1 1 *"),
+        ],
+    )
+    def test_enabled_presets_normalize_to_cron(self, preset, cron):
+        job = _job({"data_cycle_enabled": "true", "data_cycle": preset})
+        assert job.data_cycle == cron
+
+    def test_enabled_raw_cron_passes_through(self):
+        job = _job({"data_cycle_enabled": "true", "data_cycle": "0 6 * * *"})
+        assert job.data_cycle == "0 6 * * *"
+
+    def test_enabled_invalid_value_fails_loudly_at_parse(self):
+        """An invalid data_cycle must raise at DAG-parse time (job build), not
+        crash the start task at the first triggered run."""
+        with pytest.raises(ValueError, match="Invalid data cycle"):
+            _job({"data_cycle_enabled": "true", "data_cycle": "not-a-cron"})


### PR DESCRIPTION
With no data_cycle option configured (the default), IStarlakeJob.__init__ assigned the raw "none" default straight to the private field, bypassing the data_cycle setter — check_datasets gates on truthiness ("none" passes) and crashed the start task of every dataset-triggered DAG at its first triggered run with "ValueError: Invalid cron expression: none".

- Constructor now routes the option through the setter: disabled -> None, "none" -> None, presets (daily/...) -> cron, invalid value -> loud ValueError at parse time instead of a runtime crash in start.
- Getter hardened with the same data_cycle_enabled gate the setter enforces (and its annotation fixed to Optional[str]) — the invariant "no data cycle when the feature is disabled" holds at the read point.
- Latent pre-existing bug surfaced by the new tests: is_valid_cron was never imported in starlake_job.py, so the setter raised NameError on any raw cron value — import added.
- tests/orchestration/test_data_cycle.py: default/disabled/none -> None, preset table, raw cron pass-through, invalid -> ValueError (verified red-before-green: 9/10 failed unpatched).

Closes #135