### PR TITLE
fix(airflow): include task_id in the pre-load sentinel scope (#137)

### DIFF
--- a/starlake-airflow/pom.xml
+++ b/starlake-airflow/pom.xml
@@ -14,7 +14,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>starlake-airflow</artifactId>
-    <version>0.6.11</version>
+    <version>0.6.12</version>
     <packaging>jar</packaging>
 
 </project>

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/bash/starlake_airflow_bash_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/bash/starlake_airflow_bash_job.py
@@ -325,8 +325,8 @@ class StarlakePreloadBashSensor(StarlakeDatasetMixin, BashSensor):
         if self._sentinel_scope_in_environ:
             import os
             from ai.starlake.sentinel import sanitize_scope
-            dag_id, run_id = StarlakeAirflowJob._sl_sentinel_scope_parts(context)
-            scope = sanitize_scope(f"{dag_id}__{run_id}")
+            scope_parts = StarlakeAirflowJob._sl_sentinel_scope_parts(context)
+            scope = sanitize_scope("__".join(scope_parts))
             previous = os.environ.get('SL_SENTINEL_SCOPE_SAFE', None)
             os.environ['SL_SENTINEL_SCOPE_SAFE'] = scope
             try:

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_job.py
@@ -967,7 +967,10 @@ fi
     #: the ids render into data (an env var), never into shell code; the
     #: wrapper's tr whitelist then applies the same [A-Za-z0-9_.+:=-]
     #: whitelist as ai.starlake.sentinel.sanitize_scope.
-    _SL_SENTINEL_SCOPE_JINJA = "{{ ti.dag_id }}__{{ run_id }}"
+    #: task_id is part of the scope (issue #137): the sensors of a multi-table
+    #: domain poke concurrently under non-sequential executors, and a
+    #: dag+run-only scope makes them share (and cross-consume) one marker.
+    _SL_SENTINEL_SCOPE_JINJA = "{{ ti.dag_id }}__{{ ti.task_id }}__{{ run_id }}"
 
     #: Flat-wrapper sanitizer line (story 6.4 rules: no nested bash -c, no
     #: set -e). Same whitelist as sanitize_scope, but tr is BYTE-wise while
@@ -984,25 +987,32 @@ fi
 
     @classmethod
     def _sl_sentinel_scope_parts(cls, context) -> tuple:
-        """Resolve the (dag_id, run_id) scope parts from the task context.
+        """Resolve the (dag_id, task_id, run_id) scope parts from the context.
 
         dag_id is REQUIRED in the scope: run_id is only unique WITHIN one
         DAG — two generated DAGs covering the same domain on the same
         schedule tick share identical ``scheduled__...`` run_ids.
+        task_id is REQUIRED too (issue #137): a multi-table domain has one
+        preload sensor PER TABLE in the same run — without it they share one
+        marker path and cross-consume each other's verdict under concurrent
+        executors (a not-ready table then reads READY).
         """
         ti = context.get("ti", None)
         dag_id = getattr(ti, "dag_id", None)
         if not dag_id:
             dag_id = getattr(context.get("dag", None), "dag_id", None)
+        task_id = getattr(ti, "task_id", None)
+        if not task_id:
+            task_id = getattr(context.get("task", None), "task_id", None)
         run_id = context.get("run_id", None)
         if not run_id:
             run_id = getattr(context.get("dag_run", None), "run_id", None)
-        if not dag_id or not run_id:
+        if not dag_id or not task_id or not run_id:
             raise AirflowException(
-                "cannot resolve the pre-load sentinel scope — dag_id/run_id "
-                "missing from the task context"
+                "cannot resolve the pre-load sentinel scope — "
+                "dag_id/task_id/run_id missing from the task context"
             )
-        return str(dag_id), str(run_id)
+        return str(dag_id), str(task_id), str(run_id)
 
     @classmethod
     def _sl_sentinel_substitute_payload(cls, payload, context):
@@ -1013,11 +1023,11 @@ fi
         embedded in cloud payloads carries the sanitized run scope; a
         token-leak test pins that the token never reaches a submitted
         payload."""
-        dag_id, run_id = cls._sl_sentinel_scope_parts(context)
+        scope_parts = cls._sl_sentinel_scope_parts(context)
 
         def walk(value):
             if isinstance(value, str):
-                return substitute_scope(value, dag_id, run_id)
+                return substitute_scope(value, *scope_parts)
             if isinstance(value, dict):
                 return {key: walk(item) for key, item in value.items()}
             if isinstance(value, (list, tuple)):
@@ -1032,8 +1042,8 @@ fi
         substitute the run scope into the polled path, then check-and-consume
         the marker. ``True`` = READY (proceed), ``False`` = NOT READY (the
         marker was deleted FIRST — no stale positives on the next check)."""
-        dag_id, run_id = cls._sl_sentinel_scope_parts(context)
-        path = substitute_scope(sentinel_path, dag_id, run_id)
+        scope_parts = cls._sl_sentinel_scope_parts(context)
+        path = substitute_scope(sentinel_path, *scope_parts)
         return consume_sentinel(path, exists_fn, delete_fn)
 
     @classmethod

--- a/starlake-airflow/src/main/python/setup.py
+++ b/starlake-airflow/src/main/python/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 import os
 
-version = os.environ.get("PROJECT_VERSION", "0.6.11")
+version = os.environ.get("PROJECT_VERSION", "0.6.12")
 
 setup(name='starlake-airflow',
       version=version,

--- a/starlake-orchestration/pom.xml
+++ b/starlake-orchestration/pom.xml
@@ -11,7 +11,7 @@
     <name>Starlake Orchestration</name>
     <description>Starlake Orchestration templates and python library</description>
     <url>https://starlake.ai</url>
-    <version>0.5.5</version>
+    <version>0.5.6</version>
 
     <organization>
         <name>Starlake AI</name>

--- a/starlake-orchestration/src/main/python/ai/starlake/sentinel.py
+++ b/starlake-orchestration/src/main/python/ai/starlake/sentinel.py
@@ -54,7 +54,8 @@ SENTINEL_OPTION = 'pre_load_not_ready_sentinel_path'
 #: NOT a ``{{ ... }}`` Jinja placeholder: an Airflow template pass over a
 #: command string can never render it away or empty it.  Each orchestrator
 #: replaces it at RUN time with the sanitized run scope
-#: (``<dag_id>__<run_id>`` on Airflow, ``<job_name>__<run_id>`` on Dagster).
+#: (``<dag_id>__<task_id>__<run_id>`` on Airflow, ``<job_name>__<run_id>``
+#: on Dagster).
 SENTINEL_SCOPE_TOKEN = "__SL_SENTINEL_SCOPE__"
 
 #: Whitelist used by :func:`sanitize_scope` — any other character maps to

--- a/starlake-orchestration/src/main/python/setup.py
+++ b/starlake-orchestration/src/main/python/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 import os
 
-version = os.environ.get("PROJECT_VERSION", "0.5.5")
+version = os.environ.get("PROJECT_VERSION", "0.5.6")
 
 setup(name='starlake-orchestration',
       version=version,

--- a/tests/airflow/test_airflow_sl_pre_load_sentinel.py
+++ b/tests/airflow/test_airflow_sl_pre_load_sentinel.py
@@ -155,10 +155,11 @@ def _run_wrapper(command: str, tmp_path, scope: str, touch_sentinel: bool, exit_
     )
 
 
-def _fake_context(dag_id="my_dag", run_id="scheduled__2026-07-18T00:00:00+00:00", try_number=1, max_tries=4):
+def _fake_context(dag_id="my_dag", task_id="wait_for", run_id="scheduled__2026-07-18T00:00:00+00:00", try_number=1, max_tries=4):
     return {
         "ti": SimpleNamespace(
             dag_id=dag_id,
+            task_id=task_id,
             try_number=try_number,
             max_tries=max_tries,
             xcom_push=lambda **kwargs: None,
@@ -210,7 +211,7 @@ class TestBashOneShotConstruction:
         # the swallow is REMOVED: a non-zero CLI exit fails the task
         assert "exit $return_code" in cmd
         # env carries the scope as DATA (Jinja renders ids into a value)
-        assert task.env["SL_SENTINEL_SCOPE"] == "{{ ti.dag_id }}__{{ run_id }}"
+        assert task.env["SL_SENTINEL_SCOPE"] == "{{ ti.dag_id }}__{{ ti.task_id }}__{{ run_id }}"
         assert "env" in task.template_fields
 
     def test_scope_env_value_renders_ids(self, tmp_path):
@@ -218,9 +219,9 @@ class TestBashOneShotConstruction:
         task = job.sl_pre_load(domain="starbake", tables={"customers"})
         rendered = task.render_template(
             task.env,
-            {"ti": SimpleNamespace(dag_id="my_dag"), "run_id": "run_1"},
+            {"ti": SimpleNamespace(dag_id="my_dag", task_id="wait_for"), "run_id": "run_1"},
         )
-        assert rendered["SL_SENTINEL_SCOPE"] == "my_dag__run_1"
+        assert rendered["SL_SENTINEL_SCOPE"] == "my_dag__wait_for__run_1"
 
     def test_gs_prefix_rejected_on_shell(self, tmp_path):
         options = _bash_sentinel_options(tmp_path)
@@ -320,7 +321,7 @@ class TestBashSensorMode:
         # constructs (issue #125).
         expected_rec = 2 if supports_bash_retry_exit_code() else None
         assert getattr(sensor, "retry_exit_code", None) == expected_rec
-        assert sensor.env["SL_SENTINEL_SCOPE"] == "{{ ti.dag_id }}__{{ run_id }}"
+        assert sensor.env["SL_SENTINEL_SCOPE"] == "{{ ti.dag_id }}__{{ ti.task_id }}__{{ run_id }}"
         cmd = sensor.bash_command
         assert f'cd "{str(tmp_path)}" &&' in cmd
         assert "exit 2" in cmd and "exit 0" in cmd and "exit 1" in cmd
@@ -398,15 +399,48 @@ class TestSentinelScopeParts:
 
     def test_scope_parts_from_context(self):
         from ai.starlake.airflow import StarlakeAirflowJob
-        dag_id, run_id = StarlakeAirflowJob._sl_sentinel_scope_parts(_fake_context())
+        dag_id, task_id, run_id = StarlakeAirflowJob._sl_sentinel_scope_parts(_fake_context())
         assert dag_id == "my_dag"
+        assert task_id == "wait_for"
         assert run_id == "scheduled__2026-07-18T00:00:00+00:00"
 
     def test_missing_run_id_raises(self):
         from airflow.exceptions import AirflowException
         from ai.starlake.airflow import StarlakeAirflowJob
         with pytest.raises(AirflowException):
-            StarlakeAirflowJob._sl_sentinel_scope_parts({"ti": SimpleNamespace(dag_id="d")})
+            StarlakeAirflowJob._sl_sentinel_scope_parts(
+                {"ti": SimpleNamespace(dag_id="d", task_id="t")}
+            )
+
+    def test_missing_task_id_raises(self):
+        from airflow.exceptions import AirflowException
+        from ai.starlake.airflow import StarlakeAirflowJob
+        with pytest.raises(AirflowException):
+            StarlakeAirflowJob._sl_sentinel_scope_parts(
+                {"ti": SimpleNamespace(dag_id="d"), "run_id": "r"}
+            )
+
+    def test_scope_is_task_unique_within_one_run(self):
+        """Issue #137 pin: the sensors of a multi-table domain belong to ONE
+        dag run — their substituted sentinel paths MUST differ (a shared path
+        lets one wrapper consume the other's not-ready marker under a
+        concurrent executor, turning a not-ready table into a false READY)."""
+        from ai.starlake.airflow import StarlakeAirflowJob
+        from ai.starlake.sentinel import substitute_scope
+        path = f"file:///sentinels/starbake/{SENTINEL_SCOPE_TOKEN}.notready"
+        paths = {
+            substitute_scope(
+                path,
+                *StarlakeAirflowJob._sl_sentinel_scope_parts(
+                    _fake_context(task_id=task_id)
+                ),
+            )
+            for task_id in (
+                "starbake.stg_t_trs.wait_for",
+                "starbake.stg_m_trs.wait_for",
+            )
+        }
+        assert len(paths) == 2
 
 
 class TestPayloadSubstitution:
@@ -427,7 +461,7 @@ class TestPayloadSubstitution:
         )
         flattened = json.dumps(substituted)
         assert SENTINEL_SCOPE_TOKEN not in flattened
-        expected_scope = sanitize_scope("my_dag__manual 'run'")
+        expected_scope = sanitize_scope("my_dag__wait_for__manual 'run'")
         assert f"gs://b/d/{expected_scope}.notready" in flattened
         # the original payload is NOT mutated (per-attempt copies)
         assert SENTINEL_SCOPE_TOKEN in json.dumps(self.PAYLOAD)
@@ -443,7 +477,7 @@ class TestSentinelReadyHelper:
             path, _fake_context(), lambda p: True, deleted.append
         )
         assert ready is False
-        assert deleted == ["gs://b/d/my_dag__scheduled__2026-07-18T00:00:00+00:00.notready"]
+        assert deleted == ["gs://b/d/my_dag__wait_for__scheduled__2026-07-18T00:00:00+00:00.notready"]
         assert StarlakeAirflowJob._sl_sentinel_ready(
             path, _fake_context(), lambda p: False, deleted.append
         ) is True
@@ -525,7 +559,7 @@ class TestCloudPreloadSensorSentinel:
         assert verdict.xcom_value is True
 
     def test_not_ready_consumes_and_pokes_again(self):
-        expected = "gs://b/d/my_dag__scheduled__2026-07-18T00:00:00+00:00.notready"
+        expected = "gs://b/d/my_dag__wait_for__scheduled__2026-07-18T00:00:00+00:00.notready"
         store = {expected}
         verdict = self._sensor(store=store).poke(_fake_context())
         assert verdict is None  # poke again
@@ -665,7 +699,7 @@ class TestCloudRunSentinel:
         assert "${SL_SENTINEL_SCOPE_SAFE}" in cmd
         assert "tr -c 'A-Za-z0-9_.+:=-' '_'" in cmd
         assert "exit $return_code" in cmd
-        assert task.env["SL_SENTINEL_SCOPE"] == "{{ ti.dag_id }}__{{ run_id }}"
+        assert task.env["SL_SENTINEL_SCOPE"] == "{{ ti.dag_id }}__{{ ti.task_id }}__{{ run_id }}"
         assert task.append_env is True
 
     def _run_gcloud_wrapper(self, command, tmp_path, gcs_mode):
@@ -809,7 +843,7 @@ class TestCloudRunSentinel:
         options = dict(self.GS_OPTIONS, cloud_run_async="false", use_gcloud="false")
         task = self._job(options).sl_pre_load(domain="starbake", tables={"customers"})
         monkeypatch.setattr(CloudRunExecuteJobOperator, "execute", lambda self, context: "job")
-        expected = "gs://bucket/sentinels/starbake/my_dag__scheduled__2026-07-18T00:00:00+00:00.notready"
+        expected = "gs://bucket/sentinels/starbake/my_dag__wait_for__scheduled__2026-07-18T00:00:00+00:00.notready"
         store = {expected}
         monkeypatch.setattr(
             type(task), "_sl_sentinel_hook_handlers",
@@ -1042,7 +1076,7 @@ class TestFargateSentinel:
             preload=True,
             sentinel_path=sentinel,
         )
-        expected = "s3://bucket/sentinels/starbake/my_dag__scheduled__2026-07-18T00:00:00+00:00.notready"
+        expected = "s3://bucket/sentinels/starbake/my_dag__wait_for__scheduled__2026-07-18T00:00:00+00:00.notready"
         store = {expected}
         monkeypatch.setattr(
             StarlakeAirflowJob, "_sl_s3_sentinel_hook_handlers",


### PR DESCRIPTION
Fixes #137.

The pre-load sentinel scope was `<dag_id>__<run_id>`: the per-table preload sensors of a multi-table domain share one marker path within a run and cross-consume each other's verdict under concurrent executors — a not-ready table then reads READY and the downstream task fails (`SequentialExecutor` masked the race by serializing pokes; reproduced live on Airflow 3.3.0 / LocalExecutor).

Scope is now `<dag_id>__<task_id>__<run_id>`:
- `_SL_SENTINEL_SCOPE_JINJA` renders `ti.task_id` into the env value;
- `_sl_sentinel_scope_parts` returns `(dag_id, task_id, run_id)` and every consumer splats the tuple into `substitute_scope` (already variadic);
- bash-side python scope injection joins the same parts;
- `sentinel.py` docstring updated (Dagster keeps `<job_name>__<run_id>` — same theoretical exposure for concurrent multi-table jobs, left as a follow-up).

Tests: existing sentinel expectations updated to the task-scoped value + new pins (`test_scope_is_task_unique_within_one_run`, missing-task_id fail-loud). Full `tests/airflow tests/orchestration` suites green from source installs: 707 passed (Airflow 2.10.5) and 556 passed / 151 skipped (Airflow 3.3.0), runtime end-to-end included (SL_VERSION=1.6.0).

Versions: starlake-airflow 0.6.11 → 0.6.12, starlake-orchestration 0.5.5 → 0.5.6 (docstring).