### PR TITLE
fix(airflow): Airflow 3 asset-triggered transforms — event recognition + undefined-safe data_interval_end (#139)

### DIFF
--- a/starlake-airflow/pom.xml
+++ b/starlake-airflow/pom.xml
@@ -14,7 +14,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>starlake-airflow</artifactId>
-    <version>0.6.12</version>
+    <version>0.6.13</version>
     <packaging>jar</packaging>
 
 </project>

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/aws/starlake_airflow_fargate_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/aws/starlake_airflow_fargate_job.py
@@ -107,7 +107,7 @@ class StarlakeAirflowFargateJob(StarlakeAirflowJob):
             if scheduled_date:
                 tmp_arguments.append(f"{scheduled_date}")
             else:
-                tmp_arguments.append("{{sl_scheduled_date(params.cron, ts_as_datetime(data_interval_end | ts)).strftime('%Y-%m-%dT%H:%M:%S%z')}}")
+                tmp_arguments.append("{{sl_scheduled_date(params.cron, ts_as_datetime((data_interval_end | default(dag_run.run_after, true)) | ts)).strftime('%Y-%m-%dT%H:%M:%S%z')}}")
             command = arguments.pop(0)
             arguments = [command] + tmp_arguments + arguments
 

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/bash/starlake_airflow_bash_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/bash/starlake_airflow_bash_job.py
@@ -100,7 +100,7 @@ class StarlakeAirflowBashJob(StarlakeAirflowJob):
             if scheduled_date:
                 tmp_arguments.append(f"\'{scheduled_date}\'")
             else:
-                tmp_arguments.append("\'{{sl_scheduled_date(params.cron, ts_as_datetime(data_interval_end | ts)).strftime('%Y-%m-%dT%H:%M:%S%z')}}\'")
+                tmp_arguments.append("\'{{sl_scheduled_date(params.cron, ts_as_datetime((data_interval_end | default(dag_run.run_after, true)) | ts)).strftime('%Y-%m-%dT%H:%M:%S%z')}}\'")
             command = arguments.pop(0)
             arguments = [command] + tmp_arguments + arguments
 

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/gcp/starlake_airflow_cloud_run_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/gcp/starlake_airflow_cloud_run_job.py
@@ -218,7 +218,7 @@ class StarlakeAirflowCloudRunJob(StarlakeAirflowJob):
             if scheduled_date:
                 tmp_arguments.append(f"{scheduled_date}")
             else:
-                tmp_arguments.append("{{sl_scheduled_date(params.cron, ts_as_datetime(data_interval_end | ts)).strftime('%Y-%m-%dT%H:%M:%S%z')}}")
+                tmp_arguments.append("{{sl_scheduled_date(params.cron, ts_as_datetime((data_interval_end | default(dag_run.run_after, true)) | ts)).strftime('%Y-%m-%dT%H:%M:%S%z')}}")
             command = arguments.pop(0)
             arguments = [command] + tmp_arguments + arguments
         command = f'^{self.separator}^' + self.separator.join(arguments)

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/gcp/starlake_airflow_dataproc_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/gcp/starlake_airflow_dataproc_job.py
@@ -255,7 +255,7 @@ class StarlakeAirflowDataprocCluster(StarlakeAirflowOptions):
             if scheduled_date:
                 tmp_arguments.append(f"{scheduled_date}")
             else:
-                tmp_arguments.append("{{sl_scheduled_date(params.cron, ts_as_datetime(data_interval_end | ts)).strftime('%Y-%m-%dT%H:%M:%S%z')}}")
+                tmp_arguments.append("{{sl_scheduled_date(params.cron, ts_as_datetime((data_interval_end | default(dag_run.run_after, true)) | ts)).strftime('%Y-%m-%dT%H:%M:%S%z')}}")
             command = arguments.pop(0)
             arguments = [command] + tmp_arguments + arguments
         jar_list = __class__.get_context_var(var_name="spark_jar_list", options=self.options).split(",") if not jar_list else jar_list

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_job.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_job.py
@@ -94,6 +94,42 @@ class PreLoadWait(NamedTuple):
     retries: int
     retry_delay: timedelta
 
+def triggering_datasets_from_events(triggering_dataset_events) -> List[Dataset]:
+    """Normalize the triggering-events mapping into the most recent Dataset per
+    URI — version-portable (issue #139):
+
+    - Airflow 2 maps URI strings to ``DatasetEvent`` lists;
+    - the Airflow 3 task SDK maps ``Asset``/``AssetAlias`` OBJECTS to
+      ``AssetEventDagRunReference(Result)`` lists (same extra/timestamp shape).
+    """
+    triggering_uris = {}
+    dataset_uris = {}
+    for key, events in (triggering_dataset_events or {}).items():
+        uri = getattr(key, "uri", key)
+        if not isinstance(events, (list, tuple)):
+            continue
+        for event in events:
+            if type(event).__name__ not in (
+                "AssetEvent",
+                "DatasetEvent",
+                "AssetEventDagRunReference",
+                "AssetEventDagRunReferenceResult",
+            ):
+                continue
+            extra = dict(event.extra or {})
+            if not extra.get("ts", None):
+                extra.update({"ts": event.timestamp})
+            ds = Dataset(uri=uri, extra=extra)
+            if uri not in triggering_uris:
+                triggering_uris[uri] = event
+                dataset_uris.update({uri: ds})
+            else:
+                previous_event = triggering_uris[uri]
+                if event.timestamp > previous_event.timestamp:
+                    triggering_uris[uri] = event
+                    dataset_uris.update({uri: ds})
+    return list(dataset_uris.values())
+
 def sl_options_from_events(triggering_dataset_events, dag_run=None, name: Optional[str] = None) -> str:
     """Jinja macro rendering the runtime starlake --options fragment carried by the
     triggering dataset events (StarlakeParameters.OPTIONS_PARAMETER in the event
@@ -280,30 +316,7 @@ class StarlakeAirflowJob(IStarlakeJob[BaseOperator, Dataset], StarlakeAirflowOpt
                     # No triggering assets
                     return []
 
-                triggering_uris = {}
-                dataset_uris = {}
-                for uri, events in triggering_dataset_events.items():
-                    if not isinstance(events, list):
-                        continue
-
-                    for event in events:
-                        if type(event).__name__ not in ("AssetEvent", "DatasetEvent"):
-                            continue
-
-                        extra = event.extra or {}
-                        if not extra.get("ts", None):
-                            extra.update({"ts": event.timestamp})
-                        ds = Dataset(uri=uri, extra=extra)
-                        if uri not in triggering_uris:
-                            triggering_uris[uri] = event
-                            dataset_uris.update({uri: ds})
-                        else:
-                            previous_event = triggering_uris[uri]
-                            if event.timestamp > previous_event.timestamp:
-                                triggering_uris[uri] = event
-                                dataset_uris.update({uri: ds})
-
-                return list(dataset_uris.values())
+                return triggering_datasets_from_events(triggering_dataset_events)
 
             def find_previous_dag_runs_api(
                     dag,
@@ -1403,10 +1416,10 @@ class StarlakeDatasetMixin:
                     StarlakeParameters.FRESHNESS_PARAMETER.value: dataset.freshness,
                 })
                 if dataset.cron: # if the dataset is scheduled
-                    self.scheduled_dataset = "{{sl_scheduled_dataset(params.uri, params.cron, ts_as_datetime(dag_run.data_interval_end | ts), params.sl_schedule_parameter_name, params.sl_schedule_format)}}"
+                    self.scheduled_dataset = "{{sl_scheduled_dataset(params.uri, params.cron, ts_as_datetime((dag_run.data_interval_end | default(dag_run.run_after, true)) | ts), params.sl_schedule_parameter_name, params.sl_schedule_format)}}"
                 else:
                     self.scheduled_dataset = None
-                self.scheduled_date = "{{sl_scheduled_date(params.cron, ts_as_datetime(dag_run.data_interval_end | ts))}}"
+                self.scheduled_date = "{{sl_scheduled_date(params.cron, ts_as_datetime((dag_run.data_interval_end | default(dag_run.run_after, true)) | ts))}}"
                 uri = dataset.uri
             else:
                 self.scheduled_dataset = None
@@ -1418,7 +1431,7 @@ class StarlakeDatasetMixin:
                     'sl_schedule_format': None
                 })
                 kwargs['params'] = params
-                self.scheduled_date = "{{sl_scheduled_date(params.cron, ts_as_datetime(dag_run.data_interval_end | ts))}}"
+                self.scheduled_date = "{{sl_scheduled_date(params.cron, ts_as_datetime((dag_run.data_interval_end | default(dag_run.run_after, true)) | ts))}}"
             outlets.append(Dataset(uri=uri, extra=extra))
             kwargs["outlets"] = outlets
             self.template_fields = getattr(self, "template_fields", tuple()) + ("scheduled_dataset", "scheduled_date", "extra",)

--- a/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_orchestration.py
+++ b/starlake-airflow/src/main/python/ai/starlake/airflow/starlake_airflow_orchestration.py
@@ -128,7 +128,7 @@ class AirflowPipeline(AbstractPipeline[DAG, BaseOperator, TaskGroup, Dataset], A
         # contextvar is only established during rendering from Airflow 2.10 on,
         # so relying on it broke dataset-triggered DAG execution on 2.5-2.9
         # (issue #125). Template call sites are UNCHANGED: Jinja injects the
-        # context automatically, so ``ts_as_datetime(data_interval_end | ts)``
+        # context automatically, so ``ts_as_datetime((data_interval_end | default(dag_run.run_after, true)) | ts)``
         # still passes a single visible argument. The get_current_context()
         # branch is a defensive fallback for a Jinja render whose context has no
         # ``task_instance`` (Airflow always supplies it during task rendering);
@@ -203,7 +203,7 @@ class AirflowPipeline(AbstractPipeline[DAG, BaseOperator, TaskGroup, Dataset], A
 
     def sl_transform_options(self, cron_expr: Optional[str] = None) -> Optional[str]:
         if cron_expr:
-            return "{{sl_dates(params.cron_expr, ts_as_datetime(data_interval_end | ts))}}"
+            return "{{sl_dates(params.cron_expr, ts_as_datetime((data_interval_end | default(dag_run.run_after, true)) | ts))}}"
         return None
 
     def deploy(self, **kwargs) -> None:

--- a/starlake-airflow/src/main/python/setup.py
+++ b/starlake-airflow/src/main/python/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 import os
 
-version = os.environ.get("PROJECT_VERSION", "0.6.12")
+version = os.environ.get("PROJECT_VERSION", "0.6.13")
 
 setup(name='starlake-airflow',
       version=version,

--- a/tests/airflow/test_airflow_asset_triggered_context.py
+++ b/tests/airflow/test_airflow_asset_triggered_context.py
@@ -1,0 +1,152 @@
+#
+# Copyright © 2025 Starlake AI (https://starlake.ai)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Issue #139 — asset-triggered transform DAGs on Airflow 3.
+
+Two version-portability gaps, pinned here:
+
+1. The Airflow 3 task SDK hands ``triggering_asset_events`` as a mapping of
+   ``Asset``/``AssetAlias`` OBJECTS to ``AssetEventDagRunReference(Result)``
+   lists — the previous recognition only accepted URI-string keys and
+   ``AssetEvent``/``DatasetEvent`` class names, so every asset-triggered run
+   fell back to "No triggering datasets found. Manually triggered.".
+2. An Airflow 3 asset-triggered run has NO data interval and the SDK omits
+   ``data_interval_end`` from the Jinja context entirely — templates
+   referencing it crashed at render time (``UndefinedError``) before the
+   ``ts_as_datetime``/``sl_dates`` macros could apply their XCom fallback.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import jinja2
+import pytest
+
+from ai.starlake.airflow.starlake_airflow_job import triggering_datasets_from_events
+
+
+def _event(cls_name: str, extra: dict, ts: datetime):
+    """Build an event object whose class NAME mimics the orchestrator model."""
+    cls = type(cls_name, (), {})
+    event = cls()
+    event.extra = extra
+    event.timestamp = ts
+    return event
+
+
+TS_1 = datetime(2026, 7, 25, 6, 0, tzinfo=timezone.utc)
+TS_2 = datetime(2026, 7, 25, 7, 0, tzinfo=timezone.utc)
+
+
+class TestTriggeringDatasetsFromEvents:
+
+    def test_airflow2_shape_uri_keys_and_dataset_events(self):
+        events = {"starbake_customers": [_event("DatasetEvent", {"k": "v"}, TS_1)]}
+        datasets = triggering_datasets_from_events(events)
+        assert [d.uri for d in datasets] == ["starbake_customers"]
+        assert datasets[0].extra["k"] == "v"
+        assert datasets[0].extra["ts"] == TS_1  # ts injected from the event
+
+    def test_airflow3_shape_asset_keys_and_reference_events(self):
+        """The Airflow 3 accessor maps Asset OBJECTS to
+        AssetEventDagRunReferenceResult lists — both must be recognized."""
+        asset_key = type("Asset", (), {"uri": "starbake_customers", "name": "starbake_customers"})()
+        events = {
+            asset_key: [
+                _event("AssetEventDagRunReferenceResult", {"k": "v"}, TS_1)
+            ]
+        }
+        datasets = triggering_datasets_from_events(events)
+        assert [d.uri for d in datasets] == ["starbake_customers"]
+        assert datasets[0].extra["k"] == "v"
+
+    def test_unknown_event_types_are_ignored(self):
+        events = {"starbake_customers": [_event("SomethingElse", {}, TS_1)]}
+        assert triggering_datasets_from_events(events) == []
+
+    def test_latest_event_wins_per_uri(self):
+        events = {
+            "starbake_customers": [
+                _event("AssetEventDagRunReference", {"which": "old"}, TS_1),
+                _event("AssetEventDagRunReference", {"which": "new"}, TS_2),
+            ]
+        }
+        datasets = triggering_datasets_from_events(events)
+        assert len(datasets) == 1
+        assert datasets[0].extra["which"] == "new"
+
+    def test_event_extra_is_not_mutated(self):
+        extra = {"k": "v"}
+        events = {"uri": [_event("DatasetEvent", extra, TS_1)]}
+        triggering_datasets_from_events(events)
+        assert extra == {"k": "v"}  # the injected "ts" lands on a COPY
+
+    def test_empty_or_none_mapping(self):
+        assert triggering_datasets_from_events(None) == []
+        assert triggering_datasets_from_events({}) == []
+
+
+class TestDataIntervalEndFallback:
+
+    def _transform_command(self):
+        from ai.starlake.airflow.bash.starlake_airflow_bash_job import StarlakeAirflowBashJob
+        job = StarlakeAirflowBashJob(
+            filename="test_airflow.py",
+            module_name="tests.airflow.test_airflow_asset_triggered_context",
+            options={},
+        )
+        task = job.sl_transform(
+            task_id="kpi_order_summary",
+            transform_name="kpi.order_summary",
+        )
+        return task.bash_command
+
+    def test_scheduled_date_template_is_undefined_safe(self):
+        command = self._transform_command()
+        assert "data_interval_end | default(dag_run.run_after, true)" in command
+
+    def test_render_without_data_interval_end(self):
+        """Asset-triggered Airflow 3 context: NO data_interval_end at all —
+        the template must render (the macro receives dag_run.run_after)."""
+        command = self._transform_command()
+        received = {}
+
+        def sl_scheduled_date(cron, value):
+            received["value"] = value
+            return datetime(2026, 7, 25, 8, 0, tzinfo=timezone.utc)
+
+        env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+        env.filters["ts"] = lambda value: value  # Airflow's | ts filter stand-in
+        run_after = datetime(2026, 7, 25, 7, 30, tzinfo=timezone.utc)
+        rendered = env.from_string(command).render(
+            params={"cron": None, "cron_expr": None},
+            dag_run=SimpleNamespace(run_after=run_after),
+            sl_scheduled_date=sl_scheduled_date,
+            ts_as_datetime=lambda value: value,
+            sl_dates=lambda *args: "",
+            sl_options_from_events=lambda *args: "sl_options_applied=0",
+            triggering_asset_events={},
+        )
+        assert rendered  # no UndefinedError
+        assert received["value"] == run_after
+
+    def test_pipeline_transform_options_are_undefined_safe(self):
+        from ai.starlake.airflow.starlake_airflow_orchestration import AirflowPipeline
+        # the method only consults cron_expr — a bare self keeps the test light
+        options = AirflowPipeline.sl_transform_options(SimpleNamespace(), "0 6 * * *")
+        assert options is not None
+        assert "data_interval_end | default(dag_run.run_after, true)" in options


### PR DESCRIPTION
Fixes #139. Stacked on #138 (branched from fix/issue-137) — retarget to main once #138 merges.

Two Airflow 3 gaps reproduced live (3.3.0, LocalExecutor, dataset-triggered transform):

1. **Triggering events unrecognized** — the AF3 task SDK maps Asset/AssetAlias OBJECTS to `AssetEventDagRunReferenceResult` lists; the recognition only accepted URI-string keys + `AssetEvent`/`DatasetEvent` class names → every asset-triggered run logged `No triggering datasets found. Manually triggered.` Recognition extracted to a module-level, version-portable `triggering_datasets_from_events` (both shapes, non-mutating).
2. **`data_interval_end` undefined at render** — AF3 asset-triggered runs carry no data interval and the SDK omits the variable entirely; the fallback argument of `ts_as_datetime`/`sl_dates` killed the render before the macros could prefer the start-task XComs. All call sites now use `(data_interval_end | default(dag_run.run_after, true)) | ts`.

Tests: new `tests/airflow/test_airflow_asset_triggered_context.py` (9 tests — AF2/AF3 event shapes, latest-wins, non-mutation, template pin + StrictUndefined render without `data_interval_end`). Full suites green from source installs: 716 passed (Airflow 2.10.5), 565 passed / 151 skipped (Airflow 3.3.0).

Version: starlake-airflow 0.6.12 → 0.6.13.